### PR TITLE
Using 'species' instead of 'name' to discriminate object types.

### DIFF
--- a/libs/dataframe.js
+++ b/libs/dataframe.js
@@ -205,17 +205,17 @@ class DataFrame {
 
   /**
    * Summarize values (possibly grouped).
-   * @param {Summarizer} op What to do.
+   * @param {Summarizer} action What to do.
    * @returns A new dataframe.
    */
-  summarize (op) {
-    util.check(op instanceof Summarize.base,
+  summarize (action) {
+    util.check(action instanceof Summarize.base,
                `Operation must be summarizer object`)
-    util.check(this.hasColumns([op.column]),
+    util.check(this.hasColumns([action.column]),
                `unknown column in summarize`)
     const newData = this.data.map(row => { return {...row} })
-    const destCol = `${op.column}_${op.name}`
-    this._summarizeColumn(newData, op, destCol)
+    const destCol = `${action.column}_${action.species}`
+    this._summarizeColumn(newData, action, destCol)
     return new DataFrame(newData, [destCol])
   }
 
@@ -341,17 +341,17 @@ class DataFrame {
 
   /**
    * Test whether the dataframe has the specified columns.
-   * @param {string[]} names Names of column to check for.
+   * @param {string[]} colNames Names of column to check for.
    * @param {Boolean} exact Must column names match exactly?
    * @returns {Boolean} Are columns present?
    */
-  hasColumns (names, exact = false) {
-    util.check(Array.isArray(names),
+  hasColumns (colNames, exact = false) {
+    util.check(Array.isArray(colNames),
                `require array of names`)
-    if (exact && (names.length !== this.columns.size)) {
+    if (exact && (colNames.length !== this.columns.size)) {
       return false
     }
-    return names.every(n => (this.columns.has(n)))
+    return colNames.every(n => (this.columns.has(n)))
   }
 
   // ------------------------------------------------------------------------------
@@ -385,9 +385,9 @@ class DataFrame {
       return
     }
     const expected = new Set(Object.keys(values[0]))
-    expected.forEach(name => {
-      util.check(name.match(DataFrame.COLUMN_NAME) || DataFrame.SPECIAL_NAMES.has(name),
-                 `Column name "${name}" not allowed`)
+    expected.forEach(colName => {
+      util.check(colName.match(DataFrame.COLUMN_NAME) || DataFrame.SPECIAL_NAMES.has(colName),
+                 `Column name "${colName}" not allowed`)
     })
     values.forEach((row, index) => {
       const keys = Object.keys(row)
@@ -432,10 +432,10 @@ class DataFrame {
     // Construct.
     else {
       if (oldColumns) {
-        oldColumns.forEach(name => result.add(name))
+        oldColumns.forEach(colName => result.add(colName))
       }
       if ('add' in extras) {
-        extras.add.forEach(name => result.add(name))
+        extras.add.forEach(colName => result.add(colName))
       }
     }
 
@@ -473,7 +473,7 @@ class DataFrame {
   //
   // Summarize a single column in place.
   //
-  _summarizeColumn (data, op, destCol) {
+  _summarizeColumn (data, action, destCol) {
     // Divide values into groups.
     const groups = new Map()
     data.forEach(row => {
@@ -486,7 +486,7 @@ class DataFrame {
 
     // Summarize each group.
     for (let groupId of groups.keys()) {
-      const result = op.run(groups.get(groupId))
+      const result = action.run(groups.get(groupId))
       groups.set(groupId, result)
     }
 

--- a/libs/env.js
+++ b/libs/env.js
@@ -5,7 +5,7 @@ const DataFrame = require('./dataframe')
 
 /**
  * Runtime environment.
- * @param userData Datasets loaded by the user (keyed by name).
+ * @param userData Datasets loaded by the user (keyed by label).
  */
 class Env {
   /**
@@ -22,85 +22,85 @@ class Env {
   }
 
   /**
-   * Get a dataset by name. This checks the results first, then the userData.
-   * @param {string} name Identifier for data.
+   * Get a dataset by label. This checks the results first, then the userData.
+   * @param {string} label Identifier for data.
    * @returns Data table to be converted to dataframe.
    */
-  getData (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as dataset name`)
-    if (this.results.has(name)) {
-      return this.results.get(name)
+  getData (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as dataset label`)
+    if (this.results.has(label)) {
+      return this.results.get(label)
     }
-    if (this.userData.has(name)) {
-      return this.userData.get(name)
+    if (this.userData.has(label)) {
+      return this.userData.get(label)
     }
-    util.fail(`Dataset ${name} not known`)
+    util.fail(`Dataset ${label} not known`)
   }
 
   /**
    * Add a named dataset to results.
-   * @param {string} name Identifier for data.
+   * @param {string} label Identifier for data.
    * @param {Object[]} data Data table.
    */
-  setResult (name, data) {
-    util.check(name && (typeof name === 'string') && (name.length > 0),
-               `Require non-empty string name for result`)
+  setResult (label, data) {
+    util.check(label && (typeof label === 'string') && (label.length > 0),
+               `Require non-empty string label for result`)
     util.check(data instanceof DataFrame,
                `Require dataframe for data`)
-    util.check(!this.results.has(name),
-               `Result with name ${name} already exists`)
-    this.results.set(name, data)
+    util.check(!this.results.has(label),
+               `Result with label ${label} already exists`)
+    this.results.set(label, data)
   }
 
   /**
    * Get a Vega-Lite plot spec.
-   * @param name Name of plot result to get.
+   * @param label Name of plot result to get.
    */
-  getPlot (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as plot name`)
-    util.check(this.plots.has(name),
-               `Unknown plot name ${name}`)
-    return this.plots.get(name)
+  getPlot (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as plot label`)
+    util.check(this.plots.has(label),
+               `Unknown plot label ${label}`)
+    return this.plots.get(label)
   }
   
   /**
    * Store a Vega-Lite plot spec.
-   * @param name Name of result.
+   * @param label Name of result.
    * @param {Object} spec Vega-Lite plot spec.
    */
-  setPlot (name, spec) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as plot name`)
-    util.check(!this.plots.has(name),
-               `Duplicate plot name ${name}`)
-    this.plots.set(name, spec)
+  setPlot (label, spec) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as plot label`)
+    util.check(!this.plots.has(label),
+               `Duplicate plot label ${label}`)
+    this.plots.set(label, spec)
   }
 
   /**
    * Get a statistical result.
-   * @param name Name of result to get.
+   * @param label Name of result to get.
    */
-  getStats (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as statistics name`)
-    util.check(this.stats.has(name),
-               `Unknown stats name ${name}`)
-    return this.stats.get(name)
+  getStats (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as statistics label`)
+    util.check(this.stats.has(label),
+               `Unknown stats label ${label}`)
+    return this.stats.get(label)
   }
   
   /**
    * Store a statistical result.
-   * @param name Name of result to get.
+   * @param label Name of result to get.
    * @param {Object} result Result to store.
    */
-  setStats (name, spec) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as stats name`)
-    util.check(!this.stats.has(name),
-               `Duplicate stats name ${name}`)
-    this.stats.set(name, spec)
+  setStats (label, spec) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as stats label`)
+    util.check(!this.stats.has(label),
+               `Duplicate stats label ${label}`)
+    this.stats.set(label, spec)
   }
 
   /**

--- a/libs/op.js
+++ b/libs/op.js
@@ -15,8 +15,8 @@ const FAMILY = '@op'
  * Negations.
  */
 class OpNegationBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 }
 
@@ -60,8 +60,8 @@ class OpNot extends OpNegationBase {
  * Unary type-checking expressions.
  */
 class OpTypecheckBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 
   typeCheck (row, i, typeName) {
@@ -155,8 +155,8 @@ class OpIsText extends OpTypecheckBase {
  * Unary type conversion expressions.
  */
 class OpConvertBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 }
 
@@ -257,8 +257,8 @@ class OpToString extends OpConvertBase {
  * Unary datetime expressions.
  */
 class OpDatetimeBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 
   dateValue (row, i, func) {
@@ -267,7 +267,7 @@ class OpDatetimeBase extends ExprUnary {
       return util.MISSING
     }
     util.check(value instanceof Date,
-               `Require date for ${this.kind}`)
+               `Require date for ${this.species}`)
     return func(value)
   }
 }
@@ -383,17 +383,17 @@ class OpToSeconds extends OpDatetimeBase {
  * Binary arithmetic expressions.
  */
 class OpArithmeticBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 
   arithmetic (row, i, func) {
     const left = this.left.run(row, i)
     util.checkNumber(left,
-                     `Require number for ${this.kind}`)
+                     `Require number for ${this.species}`)
     const right = this.right.run(row, i)
     util.checkNumber(right,
-                     `Require number for ${this.kind}`)
+                     `Require number for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : util.safeValue(func(left, right))
@@ -502,15 +502,15 @@ class OpSubtract extends OpArithmeticBase {
  * Binary comparison expressions.
  */
 class OpCompareBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 
   comparison (row, i, func) {
     const left = this.left.run(row, i)
     const right = this.right.run(row, i)
     util.checkTypeEqual(left, right,
-                        `Require equal types for ${this.kind}`)
+                        `Require equal types for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : func(left, right)
@@ -619,8 +619,8 @@ class OpNotEqual extends OpCompareBase {
  * Binary logical expressions.
  */
 class OpLogicalBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 }
 

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -56,7 +56,10 @@ class Pipeline {
     }
 
     const last = this.transforms.slice(-1)[0]
-    return {name: last.produces, data: data}
+    return {
+      label: last.produces,
+      data: data
+    }
   }
 }
 Pipeline.FAMILY = '@pipeline'

--- a/libs/program.js
+++ b/libs/program.js
@@ -35,20 +35,20 @@ class Program {
   /**
    * Notify the manager that a named pipeline has finished running.
    * This enqueues pipeline functions to run if their dependencies are satisfied.
-   * @param {string} name Name of the pipeline that just completed.
+   * @param {string} label Name of the pipeline that just completed.
    * @param {Object} data The DataFrame produced by the pipeline.
    */
-  notify (name, data) {
-    util.check(name && (typeof name === 'string'),
-               `Cannot notify with empty name`)
+  notify (label, data) {
+    util.check(label && (typeof label === 'string'),
+               `Cannot notify with empty label`)
     util.check(data instanceof DataFrame,
                `Data must be a dataframe`)
     util.check(this.env instanceof Env,
                `Program must have non-null environment when notifying`)
-    this.env.setResult(name, data)
+    this.env.setResult(label, data)
     const toRemove = []
     this.waiting.forEach((dependencies, pipeline) => {
-      dependencies.delete(name)
+      dependencies.delete(label)
       if (dependencies.size === 0) {
         this.queue.push(pipeline)
         toRemove.push(pipeline)
@@ -83,9 +83,9 @@ class Program {
     try {
       while (this.queue.length > 0) {
         const pipeline = this.queue.shift()
-        const {name, data} = pipeline.run(this.env)
-        if (name) {
-          this.notify(name, data)
+        const {label, data} = pipeline.run(this.env)
+        if (label) {
+          this.notify(label, data)
         }
       }
     }

--- a/libs/summarize.js
+++ b/libs/summarize.js
@@ -8,14 +8,14 @@ const util = require('./util')
 class SummarizeBase {
   /**
    * Construct.
-   * @param {string} name Name of summarization function.
+   * @param {string} species Name of summarization function.
    * @param {string} column Which column to summarize.
    */
-  constructor (name, column) {
-    util.check(name && (typeof name === 'string') &&
+  constructor (species, column) {
+    util.check(species && (typeof species === 'string') &&
                column && (typeof column === 'string'),
-               `Require non-empty strings as name and column`)
-    this.name = name
+               `Require non-empty strings as species and column`)
+    this.species = species
     this.column = column
   }
 

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -15,19 +15,19 @@ const FAMILY = '@transform'
  */
 class TransformBase {
   /**
-   * @param {string} name What this transform is called.
+   * @param {string} species What this transform is called.
    * @param {string[]} requires What datasets are required before this can run?
    * @param {string} produces What dataset does this transform produce?
    * @param {Boolean} input Does this transform require input?
    * @param {Boolean} output Does this transform produce input?
    */
-  constructor (name, requires, produces, input, output) {
-    util.check(name && (typeof name === 'string') &&
+  constructor (species, requires, produces, input, output) {
+    util.check(species && (typeof species === 'string') &&
                Array.isArray(requires) &&
                requires.every(x => (typeof x === 'string')) &&
                ((produces === null) || (typeof produces === 'string')),
                `Bad parameters to constructor`)
-    this.name = name
+    this.species = species
     this.requires = requires
     this.produces = produces
     this.input = input
@@ -36,7 +36,7 @@ class TransformBase {
 
   equal (other) {
     return (other instanceof TransformBase) &&
-      (this.name === other.name)
+      (this.species === other.species)
   }
 
   equalColumns (other) {
@@ -45,7 +45,7 @@ class TransformBase {
     util.check('columns' in other,
                `Other object must have columns`)
     return (other instanceof TransformBase) &&
-      (this.name === other.name) &&
+      (this.species === other.species) &&
       (this.columns.length === other.columns.length) &&
       this.columns.every(x => other.columns.includes(x))
   }
@@ -55,26 +55,26 @@ class TransformBase {
 
 /**
  * Get a dataset.
- * @param {string} dataset Name of dataset.
+ * @param {string} name Name of dataset.
  */
 class TransformData extends TransformBase {
-  constructor (dataset) {
-    util.check(typeof dataset === 'string',
+  constructor (name) {
+    util.check(typeof name === 'string',
                `Expected string`)
     super('read', [], null, false, true)
-    this.dataset = dataset
+    this.name = name
   }
 
   equal (other) {
     return super.equal(other) &&
-      (this.dataset === other.dataset)
+      (this.name === other.name)
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.name}`)
     util.check(df === null,
                `Cannot provide input dataframe to reader`)
-    const loaded = env.getData(this.dataset)
+    const loaded = env.getData(this.name)
     return new DataFrame(loaded.data, loaded.columns)
   }
 }
@@ -95,7 +95,7 @@ class TransformDrop extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.columns.join(', ')}`)
     return df.drop(this.columns)
   }
 }
@@ -118,7 +118,7 @@ class TransformFilter extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(this.species)
     return df.filter(this.expr)
   }
 }
@@ -140,7 +140,7 @@ class TransformGroupBy extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.columns.join(', ')}`)
     return df.groupBy(this.columns)
   }
 }
@@ -170,7 +170,7 @@ class TransformJoin extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(this.species)
     util.check(df === null,
                `Cannot provide input dataframe to join`)
     const left = env.getData(this.leftName)
@@ -203,7 +203,7 @@ class TransformMutate extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.newName}`)
     return df.mutate(this.newName, this.expr)
   }
 }
@@ -226,7 +226,7 @@ class TransformNotify extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.label}`)
     return df
   }
 }
@@ -248,7 +248,7 @@ class TransformSelect extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.columns.join(', ')}`)
     return df.select(this.columns)
   }
 }
@@ -274,7 +274,7 @@ class TransformSequence extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.newName} ${this.limit}`)
     const raw = Array.from(
       {length: this.limit},
       (v, k) => {
@@ -307,38 +307,38 @@ class TransformSort extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.columns.join(', ')} ${this.reverse}`)
     return df.sort(this.columns, this.reverse)
   }
 }
 
 /**
  * Summarize data.
- * @param {string} op Name of operation.
+ * @param {string} action Name of operation.
  * @param {string} column Column to summarize.
  */
 class TransformSummarize extends TransformBase {
-  constructor (op, column) {
-    util.check(typeof op === 'string',
-               `Expected string as op`)
-    util.check(op in Summarize,
-               `Unknown summarization operation ${op}`)
+  constructor (action, column) {
+    util.check(typeof action === 'string',
+               `Expected string as action`)
+    util.check(action in Summarize,
+               `Unknown summarization operation ${action}`)
     util.check(typeof column === 'string',
                `Expected string as column name`)
     super('summarize', [], null, true, true)
-    this.op = op
+    this.action = action
     this.column = column
   }
 
   equal (other) {
     return super.equal(other) &&
-      (this.op === other.op) &&
+      (this.action === other.action) &&
       (this.column === other.column)
   }
 
   run (env, df) {
-    env.appendLog(this.name)
-    const summarizer = new Summarize[this.op](this.column)
+    env.appendLog(`${this.species} ${this.action} ${this.column}`)
+    const summarizer = new Summarize[this.action](this.column)
     return df.summarize(summarizer)
   }
 }
@@ -352,7 +352,7 @@ class TransformUngroup extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species}`)
     return df.ungroup()
   }
 }
@@ -374,7 +374,7 @@ class TransformUnique extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.columns.join(', ')}`)
     return df.unique(this.columns)
   }
 }
@@ -394,7 +394,7 @@ class TransformPlot extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.label}`)
     this.spec.data.values = df.data
     env.setPlot(this.label, this.spec)
   }
@@ -549,7 +549,7 @@ class TransformTTestOneSample extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.label}`)
     const samples = df.data.map(row => row[this.colName])
     const pValue = stats.tTest(samples, this.mean)
     env.setStats(this.label, pValue)
@@ -572,7 +572,7 @@ class TransformTTestPaired extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog(`${this.species} ${this.label}`)
     const known = new Set(df.data.map(row => row[this.labelCol]))
     util.check(known.size === 2,
                `Must have exactly two labels for data`)

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -12,12 +12,12 @@ const UserInterface = require('../libs/gui')
  * Testing replacement for a transform (easier constructor).
  */
 class MockTransform extends Transform.base {
-  constructor (name, func, requires, produces, input, output) {
-    super(name, requires, produces, input, output)
+  constructor (species, func, requires, produces, input, output) {
+    super(species, requires, produces, input, output)
     this.func = func
   }
   run = (runner, df) => {
-    runner.appendLog(this.name)
+    runner.appendLog(this.species)
     return this.func(runner, df)
   }
 }

--- a/test/test_dataframe.js
+++ b/test/test_dataframe.js
@@ -561,7 +561,8 @@ describe('summarize', () => {
 
   it('can summarize a single ungrouped column', (done) => {
     const df = new DataFrame(TWO_ROWS)
-    const result = df.summarize(new Summarize.count('ones'))
+    const summarizer = new Summarize.count('ones')
+    const result = df.summarize(summarizer)
     assert(result.equal(new DataFrame([{ones: 1, tens: 10,
                                         ones_count: 2},
                                        {ones: 2, tens: 20,

--- a/test/test_gui.js
+++ b/test/test_gui.js
@@ -41,7 +41,7 @@ describe('creates the interface object', () => {
     const block = gui.workspace.newBlock('data_colors')
     block.hat = 'cap'
     gui.runProgram()
-    assert.deepEqual(gui.env.log, ['read'],
+    assert.deepEqual(gui.env.log, ['read colors'],
                      `Program did not run as expected`)
     done()
   })

--- a/test/test_pipeline.js
+++ b/test/test_pipeline.js
@@ -87,7 +87,7 @@ describe('executes pipelines', () => {
   it('executes a pipeline with notification', (done) => {
     const pipeline = new Pipeline(fixture.HEAD, fixture.TAIL_NOTIFY)
     const result = pipeline.run(new Env(INTERFACE.userData))
-    assert.equal(result.name, 'keyword',
+    assert.equal(result.label, 'keyword',
                  `Result should include name`)
     assert(result.data.equal(fixture.TABLE),
            `Result should contain unmodified table`)
@@ -95,10 +95,10 @@ describe('executes pipelines', () => {
   })
 
   it('logs execution', (done) => {
-    const runner = new Env(INTERFACE.userData)
+    const env = new Env(INTERFACE.userData)
     const pipeline = new Pipeline(fixture.HEAD, fixture.MIDDLE, fixture.TAIL)
-    const result = pipeline.run(runner)
-    assert.deepEqual(runner.log, ['head', 'middle', 'tail'],
+    const result = pipeline.run(env)
+    assert.deepEqual(env.log, ['head', 'middle', 'tail'],
                      `Transforms not logged`)
     done()
   })


### PR DESCRIPTION
Because we had too many things called 'name'.