### PR TITLE
Show messages

### DIFF
--- a/blocks/op.js
+++ b/blocks/op.js
@@ -23,11 +23,11 @@ const setup = () => {
           name: 'OP',
           options: [
             ['+', 'add'],
-            ['-', 'sub'],
-            ['\u00D7', 'mul'],
-            ['\u00F7', 'div'],
-            ['%', 'mod'],
-            ['^', 'exp']
+            ['-', 'subtract'],
+            ['\u00D7', 'multiply'],
+            ['\u00F7', 'divide'],
+            ['%', 'remainder'],
+            ['^', 'power']
           ]
         },
         {
@@ -72,12 +72,12 @@ const setup = () => {
           type: 'field_dropdown',
           name: 'OP',
           options: [
-            ['=', 'eq'],
-            ['\u2260', 'neq'],
-            ['\u200F<', 'lt'],
-            ['\u200F\u2264', 'leq'],
-            ['\u200F>', 'gt'],
-            ['\u200F\u2265', 'geq']
+            ['=', 'equal'],
+            ['\u2260', 'notEqual'],
+            ['\u200F<', 'less'],
+            ['\u200F\u2264', 'lessEqual'],
+            ['\u200F>', 'greater'],
+            ['\u200F\u2265', 'greaterEqual']
           ]
         },
         {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <script>
       let ui = null
       window.onload = () => {
-        ui = tidyblocks.setup('root', 'toolbox')
+        TidyBlocksUI = tidyblocks.setup('root', 'toolbox')
       }
     </script>
   </head>

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const React = require('react');
 const Blockly = require('blockly/blockly_compressed')
 
 const blocks = require('./blocks/blocks')
+const Env = require('./libs/env')
 const UserInterface = require('./libs/gui')
 const TidyBlocksApp = require('./libs/ui/ui').TidyBlocksApp
 
@@ -32,9 +33,12 @@ class ReactInterface extends UserInterface {
     const serializer = new XMLSerializer()
     const toolboxString = serializer.serializeToString(toolbox)
 
+    // Create an environment so that the React app can get at the pre-loaded datasets.
+    const env = new Env(this)
+
     // Render React, saving the React app.
     this.app = ReactDOM.render(
-      <TidyBlocksApp settings={settings} toolbox={toolboxString}/>,
+      <TidyBlocksApp settings={settings} toolbox={toolboxString} initialEnv={env}/>,
       document.getElementById(rootId)
     )
 

--- a/libs/dataframe.js
+++ b/libs/dataframe.js
@@ -205,17 +205,17 @@ class DataFrame {
 
   /**
    * Summarize values (possibly grouped).
-   * @param {Summarizer} op What to do.
+   * @param {Summarizer} action What to do.
    * @returns A new dataframe.
    */
-  summarize (op) {
-    util.check(op instanceof Summarize.base,
+  summarize (action) {
+    util.check(action instanceof Summarize.base,
                `Operation must be summarizer object`)
-    util.check(this.hasColumns([op.column]),
+    util.check(this.hasColumns([action.column]),
                `unknown column in summarize`)
     const newData = this.data.map(row => { return {...row} })
-    const destCol = `${op.column}_${op.name}`
-    this._summarizeColumn(newData, op, destCol)
+    const destCol = `${action.column}_${action.species}`
+    this._summarizeColumn(newData, action, destCol)
     return new DataFrame(newData, [destCol])
   }
 
@@ -341,17 +341,17 @@ class DataFrame {
 
   /**
    * Test whether the dataframe has the specified columns.
-   * @param {string[]} names Names of column to check for.
+   * @param {string[]} colNames Names of column to check for.
    * @param {Boolean} exact Must column names match exactly?
    * @returns {Boolean} Are columns present?
    */
-  hasColumns (names, exact = false) {
-    util.check(Array.isArray(names),
+  hasColumns (colNames, exact = false) {
+    util.check(Array.isArray(colNames),
                `require array of names`)
-    if (exact && (names.length !== this.columns.size)) {
+    if (exact && (colNames.length !== this.columns.size)) {
       return false
     }
-    return names.every(n => (this.columns.has(n)))
+    return colNames.every(n => (this.columns.has(n)))
   }
 
   // ------------------------------------------------------------------------------
@@ -385,9 +385,9 @@ class DataFrame {
       return
     }
     const expected = new Set(Object.keys(values[0]))
-    expected.forEach(name => {
-      util.check(name.match(DataFrame.COLUMN_NAME) || DataFrame.SPECIAL_NAMES.has(name),
-                 `Column name "${name}" not allowed`)
+    expected.forEach(colName => {
+      util.check(colName.match(DataFrame.COLUMN_NAME) || DataFrame.SPECIAL_NAMES.has(colName),
+                 `Column name "${colName}" not allowed`)
     })
     values.forEach((row, index) => {
       const keys = Object.keys(row)
@@ -432,10 +432,10 @@ class DataFrame {
     // Construct.
     else {
       if (oldColumns) {
-        oldColumns.forEach(name => result.add(name))
+        oldColumns.forEach(colName => result.add(colName))
       }
       if ('add' in extras) {
-        extras.add.forEach(name => result.add(name))
+        extras.add.forEach(colName => result.add(colName))
       }
     }
 
@@ -473,7 +473,7 @@ class DataFrame {
   //
   // Summarize a single column in place.
   //
-  _summarizeColumn (data, op, destCol) {
+  _summarizeColumn (data, action, destCol) {
     // Divide values into groups.
     const groups = new Map()
     data.forEach(row => {
@@ -486,7 +486,7 @@ class DataFrame {
 
     // Summarize each group.
     for (let groupId of groups.keys()) {
-      const result = op.run(groups.get(groupId))
+      const result = action.run(groups.get(groupId))
       groups.set(groupId, result)
     }
 

--- a/libs/env.js
+++ b/libs/env.js
@@ -5,7 +5,7 @@ const DataFrame = require('./dataframe')
 
 /**
  * Runtime environment.
- * @param userData Datasets loaded by the user (keyed by name).
+ * @param userData Datasets loaded by the user (keyed by label).
  */
 class Env {
   /**
@@ -21,85 +21,85 @@ class Env {
   }
 
   /**
-   * Get a dataset by name. This checks the results first, then the userData.
-   * @param {string} name Identifier for data.
+   * Get a dataset by label. This checks the results first, then the userData.
+   * @param {string} label Identifier for data.
    * @returns Data table to be converted to dataframe.
    */
-  getData (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as dataset name`)
-    if (this.results.has(name)) {
-      return this.results.get(name)
+  getData (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as dataset label`)
+    if (this.results.has(label)) {
+      return this.results.get(label)
     }
-    if (this.userData.has(name)) {
-      return this.userData.get(name)
+    if (this.userData.has(label)) {
+      return this.userData.get(label)
     }
-    util.fail(`Dataset ${name} not known`)
+    util.fail(`Dataset ${label} not known`)
   }
 
   /**
    * Add a named dataset to results.
-   * @param {string} name Identifier for data.
+   * @param {string} label Identifier for data.
    * @param {Object[]} data Data table.
    */
-  setResult (name, data) {
-    util.check(name && (typeof name === 'string') && (name.length > 0),
-               `Require non-empty string name for result`)
+  setResult (label, data) {
+    util.check(label && (typeof label === 'string') && (label.length > 0),
+               `Require non-empty string label for result`)
     util.check(data instanceof DataFrame,
                `Require dataframe for data`)
-    util.check(!this.results.has(name),
-               `Result with name ${name} already exists`)
-    this.results.set(name, data)
+    util.check(!this.results.has(label),
+               `Result with label ${label} already exists`)
+    this.results.set(label, data)
   }
 
   /**
    * Get a Vega-Lite plot spec.
-   * @param name Name of plot result to get.
+   * @param label Name of plot result to get.
    */
-  getPlot (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as plot name`)
-    util.check(this.plots.has(name),
-               `Unknown plot name ${name}`)
-    return this.plots.get(name)
+  getPlot (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as plot label`)
+    util.check(this.plots.has(label),
+               `Unknown plot label ${label}`)
+    return this.plots.get(label)
   }
   
   /**
    * Store a Vega-Lite plot spec.
-   * @param name Name of result.
+   * @param label Name of result.
    * @param {Object} spec Vega-Lite plot spec.
    */
-  setPlot (name, spec) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as plot name`)
-    util.check(!this.plots.has(name),
-               `Duplicate plot name ${name}`)
-    this.plots.set(name, spec)
+  setPlot (label, spec) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as plot label`)
+    util.check(!this.plots.has(label),
+               `Duplicate plot label ${label}`)
+    this.plots.set(label, spec)
   }
 
   /**
    * Get a statistical result.
-   * @param name Name of result to get.
+   * @param label Name of result to get.
    */
-  getStats (name) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as statistics name`)
-    util.check(this.stats.has(name),
-               `Unknown stats name ${name}`)
-    return this.stats.get(name)
+  getStats (label) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as statistics label`)
+    util.check(this.stats.has(label),
+               `Unknown stats label ${label}`)
+    return this.stats.get(label)
   }
   
   /**
    * Store a statistical result.
-   * @param name Name of result to get.
+   * @param label Name of result to get.
    * @param {Object} result Result to store.
    */
-  setStats (name, spec) {
-    util.check(name && (typeof name === 'string'),
-               `Require non-empty string as stats name`)
-    util.check(!this.stats.has(name),
-               `Duplicate stats name ${name}`)
-    this.stats.set(name, spec)
+  setStats (label, spec) {
+    util.check(label && (typeof label === 'string'),
+               `Require non-empty string as stats label`)
+    util.check(!this.stats.has(label),
+               `Duplicate stats label ${label}`)
+    this.stats.set(label, spec)
   }
 
   /**
@@ -108,8 +108,8 @@ class Env {
    * @param {string} message To save.
    */
   appendLog (level, message) {
-    util.warn(level && (typeof level === 'string') && (level in ['log', 'error']),
-              `Expected either "log" or "error" for level, not "${level}"`)
+    util.check(level && (typeof level === 'string') && ['log', 'error'].includes(level),
+               `Expected either "log" or "error" for level, not "${level}"`)
     this.log.push([level, message])
   }
 }

--- a/libs/env.js
+++ b/libs/env.js
@@ -18,7 +18,6 @@ class Env {
     this.plots = new Map()
     this.stats = new Map()
     this.log = []
-    this.errors = []
   }
 
   /**
@@ -105,18 +104,13 @@ class Env {
 
   /**
    * Append a message to the runtime log.
+   * @param {string} level One of 'log' or 'error'.
    * @param {string} message To save.
    */
-  appendLog (message) {
-    this.log.push(message)
-  }
-
-  /**
-   * Append a message to the error log.
-   * @param {string} message To save.
-   */
-  appendError (message) {
-    this.errors.push(message)
+  appendLog (level, message) {
+    util.warn(level && (typeof level === 'string') && (level in ['log', 'error']),
+              `Expected either "log" or "error" for level, not "${level}"`)
+    this.log.push([level, message])
   }
 }
 

--- a/libs/op.js
+++ b/libs/op.js
@@ -15,8 +15,8 @@ const FAMILY = '@op'
  * Negations.
  */
 class OpNegationBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 }
 
@@ -60,8 +60,8 @@ class OpNot extends OpNegationBase {
  * Unary type-checking expressions.
  */
 class OpTypecheckBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 
   typeCheck (row, i, typeName) {
@@ -155,8 +155,8 @@ class OpIsText extends OpTypecheckBase {
  * Unary type conversion expressions.
  */
 class OpConvertBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 }
 
@@ -257,8 +257,8 @@ class OpToString extends OpConvertBase {
  * Unary datetime expressions.
  */
 class OpDatetimeBase extends ExprUnary {
-  constructor (kind, arg) {
-    super(FAMILY, kind, arg)
+  constructor (species, arg) {
+    super(FAMILY, species, arg)
   }
 
   dateValue (row, i, func) {
@@ -267,7 +267,7 @@ class OpDatetimeBase extends ExprUnary {
       return util.MISSING
     }
     util.check(value instanceof Date,
-               `Require date for ${this.kind}`)
+               `Require date for ${this.species}`)
     return func(value)
   }
 }
@@ -383,17 +383,17 @@ class OpToSeconds extends OpDatetimeBase {
  * Binary arithmetic expressions.
  */
 class OpArithmeticBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 
   arithmetic (row, i, func) {
     const left = this.left.run(row, i)
     util.checkNumber(left,
-                     `Require number for ${this.kind}`)
+                     `Require number for ${this.species}`)
     const right = this.right.run(row, i)
     util.checkNumber(right,
-                     `Require number for ${this.kind}`)
+                     `Require number for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : util.safeValue(func(left, right))
@@ -502,15 +502,15 @@ class OpSubtract extends OpArithmeticBase {
  * Binary comparison expressions.
  */
 class OpCompareBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 
   comparison (row, i, func) {
     const left = this.left.run(row, i)
     const right = this.right.run(row, i)
     util.checkTypeEqual(left, right,
-                        `Require equal types for ${this.kind}`)
+                        `Require equal types for ${this.species}`)
     return ((left === util.MISSING) || (right === util.MISSING))
       ? util.MISSING
       : func(left, right)
@@ -619,8 +619,8 @@ class OpNotEqual extends OpCompareBase {
  * Binary logical expressions.
  */
 class OpLogicalBase extends ExprBinary {
-  constructor (kind, left, right) {
-    super(FAMILY, kind, left, right)
+  constructor (species, left, right) {
+    super(FAMILY, species, left, right)
   }
 }
 

--- a/libs/persist.js
+++ b/libs/persist.js
@@ -61,7 +61,7 @@ class Restore {
     util.check((json.length > 1) &&
                (json[0] === Op.FAMILY) &&
                (json[1] in Op),
-               `Require indicator of known operation kind`)
+               `Require indicator of known operation kind ${JSON.stringify(json)}`)
     const kind = json[1]
     const args = json.slice(2).map(p => this.expr(p))
     return new Op[kind](...args)
@@ -71,7 +71,7 @@ class Restore {
     util.check((json.length > 1) &&
                (json[0] === Value.FAMILY) &&
                (json[1] in Value),
-               `Require indicator of known value kind`)
+               `Require indicator of known value kind ${JSON.stringify(json)}`)
     const kind = json[1]
     const args = json.slice(2).map(p => this.expr(p))
     return new Value[kind](...args)

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -56,7 +56,10 @@ class Pipeline {
     }
 
     const last = this.transforms.slice(-1)[0]
-    return {name: last.produces, data: data}
+    return {
+      label: last.produces,
+      data: data
+    }
   }
 }
 Pipeline.FAMILY = '@pipeline'

--- a/libs/program.js
+++ b/libs/program.js
@@ -35,20 +35,20 @@ class Program {
   /**
    * Notify the manager that a named pipeline has finished running.
    * This enqueues pipeline functions to run if their dependencies are satisfied.
-   * @param {string} name Name of the pipeline that just completed.
+   * @param {string} label Name of the pipeline that just completed.
    * @param {Object} data The DataFrame produced by the pipeline.
    */
-  notify (name, data) {
-    util.check(name && (typeof name === 'string'),
-               `Cannot notify with empty name`)
+  notify (label, data) {
+    util.check(label && (typeof label === 'string'),
+               `Cannot notify with empty label`)
     util.check(data instanceof DataFrame,
                `Data must be a dataframe`)
     util.check(this.env instanceof Env,
                `Program must have non-null environment when notifying`)
-    this.env.setResult(name, data)
+    this.env.setResult(label, data)
     const toRemove = []
     this.waiting.forEach((dependencies, pipeline) => {
-      dependencies.delete(name)
+      dependencies.delete(label)
       if (dependencies.size === 0) {
         this.queue.push(pipeline)
         toRemove.push(pipeline)
@@ -83,14 +83,14 @@ class Program {
     try {
       while (this.queue.length > 0) {
         const pipeline = this.queue.shift()
-        const {name, data} = pipeline.run(this.env)
-        if (name) {
-          this.notify(name, data)
+        const {label, data} = pipeline.run(this.env)
+        if (label) {
+          this.notify(label, data)
         }
       }
     }
     catch (err) {
-      this.env.appendError(`${err.message}: ${err.stack}`)
+      this.env.appendLog('error', `${err.message}: ${err.stack}`)
     }
   }
 }

--- a/libs/summarize.js
+++ b/libs/summarize.js
@@ -8,14 +8,14 @@ const util = require('./util')
 class SummarizeBase {
   /**
    * Construct.
-   * @param {string} name Name of summarization function.
+   * @param {string} species Name of summarization function.
    * @param {string} column Which column to summarize.
    */
-  constructor (name, column) {
-    util.check(name && (typeof name === 'string') &&
+  constructor (species, column) {
+    util.check(species && (typeof species === 'string') &&
                column && (typeof column === 'string'),
-               `Require non-empty strings as name and column`)
-    this.name = name
+               `Require non-empty strings as species and column`)
+    this.species = species
     this.column = column
   }
 

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -71,7 +71,7 @@ class TransformData extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     util.check(df === null,
                `Cannot provide input dataframe to reader`)
     const loaded = env.getData(this.dataset)
@@ -95,7 +95,7 @@ class TransformDrop extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.drop(this.columns)
   }
 }
@@ -118,7 +118,7 @@ class TransformFilter extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.filter(this.expr)
   }
 }
@@ -140,7 +140,7 @@ class TransformGroupBy extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.groupBy(this.columns)
   }
 }
@@ -170,7 +170,7 @@ class TransformJoin extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     util.check(df === null,
                `Cannot provide input dataframe to join`)
     const left = env.getData(this.leftName)
@@ -203,7 +203,7 @@ class TransformMutate extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.mutate(this.newName, this.expr)
   }
 }
@@ -226,7 +226,7 @@ class TransformNotify extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df
   }
 }
@@ -248,7 +248,7 @@ class TransformSelect extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.select(this.columns)
   }
 }
@@ -274,7 +274,7 @@ class TransformSequence extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     const raw = Array.from(
       {length: this.limit},
       (v, k) => {
@@ -307,7 +307,7 @@ class TransformSort extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.sort(this.columns, this.reverse)
   }
 }
@@ -337,7 +337,7 @@ class TransformSummarize extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     const summarizer = new Summarize[this.op](this.column)
     return df.summarize(summarizer)
   }
@@ -352,7 +352,7 @@ class TransformUngroup extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.ungroup()
   }
 }
@@ -374,7 +374,7 @@ class TransformUnique extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     return df.unique(this.columns)
   }
 }
@@ -394,7 +394,7 @@ class TransformPlot extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     this.spec.data.values = df.data
     env.setPlot(this.label, this.spec)
   }
@@ -549,7 +549,7 @@ class TransformTTestOneSample extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     const samples = df.data.map(row => row[this.colName])
     const pValue = stats.tTest(samples, this.mean)
     env.setStats(this.label, pValue)
@@ -572,7 +572,7 @@ class TransformTTestPaired extends TransformBase {
   }
 
   run (env, df) {
-    env.appendLog(this.name)
+    env.appendLog('log', this.name)
     const known = new Set(df.data.map(row => row[this.labelCol]))
     util.check(known.size === 2,
                `Must have exactly two labels for data`)

--- a/libs/ui/menuBar.jsx
+++ b/libs/ui/menuBar.jsx
@@ -23,16 +23,16 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import InboxIcon from '@material-ui/icons/MoveToInbox'
 import MailIcon from '@material-ui/icons/Mail'
-import CssBaseline from '@material-ui/core/CssBaseline';
-import Hidden from '@material-ui/core/Hidden';
-import CloseIcon from '@material-ui/icons/Close';
+import CssBaseline from '@material-ui/core/CssBaseline'
+import Hidden from '@material-ui/core/Hidden'
+import CloseIcon from '@material-ui/icons/Close'
 
 // Menu Items to display for the Save button.
 function SaveMenuItems(){
 
   const handleClose = () => {
-    setAnchorEl(null);
-  };
+    setAnchorEl(null)
+  }
 
   return (
     <React.Fragment>
@@ -51,20 +51,20 @@ function TidyBlocksButtonItem({name, icon, handleClick}) {
         {name}
       </Button>
     </div>
-  );
+  )
 }
 
 // Create a Menu Item for the top TidyBlocks bar.
 function TidyBlocksMenuItem({name, icon, menuItems}) {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
+  const [anchorEl, setAnchorEl] = React.useState(null)
+  const open = Boolean(anchorEl)
   const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
+    setAnchorEl(event.currentTarget)
+  }
 
   const handleClose = () => {
-    setAnchorEl(null);
-  };
+    setAnchorEl(null)
+  }
 
   return (
     <div>
@@ -84,13 +84,13 @@ function TidyBlocksMenuItem({name, icon, menuItems}) {
       }
 
     </div>
-  );
+  )
 }
 
 // Defines the top level menu bar for the page.
 export class MenuBar extends React.Component{
   constructor(props){
-    super(props);
+    super(props)
     this.state = {
       mobileOpen: false,
     }
@@ -103,15 +103,15 @@ export class MenuBar extends React.Component{
     console.log(this.state.mobileOpen)
 
     const mobileOpen = this.state.mobileOpen
-    this.setState({mobileOpen: !mobileOpen});
+    this.setState({mobileOpen: !mobileOpen})
     // setMobileOpen(!mobileOpen)
   }
 
   render(){
-    const classes = withStyles(MenuBar);
-    const theme = withTheme(MenuBar);
+    const classes = withStyles(MenuBar)
+    const theme = withTheme(MenuBar)
 
-    // const [mobileOpen, setMobileOpen] = React.useState(false);
+    // const [mobileOpen, setMobileOpen] = React.useState(false)
     const drawer = (
       <div>
       <List>
@@ -127,7 +127,7 @@ export class MenuBar extends React.Component{
         </ListItem>
       </List>
       </div>
-    );
+    )
 
 
     return (
@@ -146,7 +146,7 @@ export class MenuBar extends React.Component{
               <TidyBlocksButtonItem name="Run" icon={<PlayArrowIcon className="menuIcon" fontSize="large"/>} handleClick={this.props.runProgram}/>
               <TidyBlocksButtonItem name="Load Workspace" icon={<PublishIcon className="menuIcon" fontSize="large"/>} handleClick={this.props.runProgram}/>
               <TidyBlocksButtonItem name="Load CSV" icon={<TableChartIcon className="menuIcon" fontSize="large"/>} handleClick={this.props.runProgram}/>
-              <TidyBlocksMenuItem name="Save" menuItems={<SaveMenuItems/>} icon={<SaveIcon className="menuIcon" fontSize="large"/>}/>
+              <TidyBlocksMenuItem name="Save..." menuItems={<SaveMenuItems/>} icon={<SaveIcon className="menuIcon" fontSize="large"/>}/>
           </Toolbar>
         </AppBar>
         <Toolbar />
@@ -172,6 +172,6 @@ export class MenuBar extends React.Component{
           </Hidden>
         </nav>
       </React.Fragment>
-    );
+    )
   }
 }

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -129,6 +129,7 @@ export class TidyBlocksApp extends React.Component{
       statsValue: null,
       activeStatsOption: null,
 
+      logMessages: null
     }
     this.paneVerticalResize = this.paneVerticalResize.bind(this)
     this.paneHorizontalResize = this.paneHorizontalResize.bind(this)
@@ -139,7 +140,7 @@ export class TidyBlocksApp extends React.Component{
     this.changeData = this.changeData.bind(this)
     this.handleTabChange = this.handleTabChange.bind(this)
     this.sortRows = this.sortRows.bind(this)
-
+    this.updateLogMessages = this.updateLogMessages.bind(this)
   }
 
   componentDidMount () {
@@ -244,6 +245,10 @@ export class TidyBlocksApp extends React.Component{
       dataColumns: formattedColumns})
   }
 
+  updateLogMessages (env) {
+    this.setState({logMessages: env.log})
+  }
+
   runProgram () {
     TidyBlocksUI.runProgram()
     const env = TidyBlocksUI.env
@@ -252,6 +257,7 @@ export class TidyBlocksApp extends React.Component{
     this.updateDataInformation(env)
     this.updatePlotInformation(env)
     this.updateStatsInformation(env)
+    this.updateLogMessages(env)
   }
 
   updateDataInformation (env) {
@@ -361,6 +367,10 @@ export class TidyBlocksApp extends React.Component{
 
   render () {
     const classes = withStyles(Tabs)
+    const logMessages = this.state.logMessages
+          ? this.state.logMessages.map((msg, i) => <li><code>{msg[0]}: {msg[1]}</code></li>) // FIXME: should give each a key
+          : <li>No messages</li>
+    const logMessageList = <ul>{logMessages}</ul>
     return (
       <div >
         <MenuBar runProgram={this.runProgram}/>
@@ -415,12 +425,12 @@ export class TidyBlocksApp extends React.Component{
                   <div className="relativeWrapper">
                     <div className="absoluteWrapper">
                       <div className="dataWrapper">
-
                       </div>
                     </div>
                   </div>
                 </TabPanel>
                 <TabPanel value={this.state.tabValue} index={2}>
+                  {logMessages}
                 </TabPanel>
               </div>
             </Pane>

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -381,7 +381,6 @@ export class TidyBlocksApp extends React.Component{
                     <Tab label="Data" {...a11yProps(0)} />
                     <Tab label="Stats" {...a11yProps(1)} />
                     <Tab label="Console" {...a11yProps(2)} />
-                    <Tab label="Item Four" {...a11yProps(3)} />
                   </Tabs>
                 </AppBar>
                 <TabPanel value={this.state.tabValue} index={0} component="div">
@@ -412,10 +411,6 @@ export class TidyBlocksApp extends React.Component{
                   </div>
                 </TabPanel>
                 <TabPanel value={this.state.tabValue} index={2}>
-                  Item Three
-                </TabPanel>
-                <TabPanel value={this.state.tabValue} index={3}>
-                  Item Four
                 </TabPanel>
               </div>
             </Pane>

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -97,6 +97,9 @@ export class TidyBlocksApp extends React.Component{
     this.bottomRightPaneRef = React.createRef()
     this.dataGridRef = React.createRef()
 
+    // Get the initial environment so that we can pre-populate the datasets.
+    const initialEnv = props.initialEnv
+
     this.state = {
       topRightPaneHeight: 200,
 

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -242,8 +242,8 @@ export class TidyBlocksApp extends React.Component{
   }
 
   runProgram () {
-    ui.runProgram()
-    const env = ui.env
+    TidyBlocksUI.runProgram()
+    const env = TidyBlocksUI.env
     console.log(env)
 
     // Updates Data Information.

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -246,7 +246,12 @@ export class TidyBlocksApp extends React.Component{
     const env = TidyBlocksUI.env
     console.log(env)
 
-    // Updates Data Information.
+    this.updateDataInformation(env)
+    this.updatePlotInformation(env)
+    this.updateStatsInformation(env)
+  }
+
+  updateDataInformation (env) {
     const dataKeys = env.userData.keys()
     let data = null
     let dataColumns = null
@@ -281,8 +286,9 @@ export class TidyBlocksApp extends React.Component{
     console.log(formattedColumns)
     this.setState({dataKeys:dataKeys, data: data, dataColumns: formattedColumns,
       activeDataOption: activeDataOption, dataOptions: dataOptions})
+  }
 
-    // Updates Plot Information.
+  updatePlotInformation (env) {
     const plotKeys = env.plots.keys()
     let plotData = null
     let activePlotOption = null
@@ -311,7 +317,9 @@ export class TidyBlocksApp extends React.Component{
       activePlotOption: activePlotOption, plotOptions: plotOptions}, () => {
       this.updatePlot()
     })
+  }
 
+  updateStatsInformation (env) {
     // Updates Stats information. DISABLED PENDING FORMAT DISCUSSION.
     // const statsKeys = env.stats.keys()
     // let stats = null
@@ -342,7 +350,6 @@ export class TidyBlocksApp extends React.Component{
     // }
     // this.setState({statsKeys:statsKeys, stats: stats, statsColumns: formattedStatsColumns,
     //   activeStatsOption: activeStatsOption, statsOptions: statsOptions})
-    //
   }
 
   handleTabChange (event, newValue) {

--- a/libs/util.js
+++ b/libs/util.js
@@ -22,6 +22,17 @@ const check = (condition, message) => {
 }
 
 /**
+ * Print warning message if condition fails but otherwise do nothing.
+ * @param {Boolean} condition Condition that must be true.
+ * @param {string} message What to say if it isn't.
+ */
+const warn = (condition, message) => {
+  if (!condition) {
+    console.warn(message)
+  }
+}
+
+/**
  * Check that a value is numeric.
  * @param {whatever} value What to check.
  */

--- a/libs/util.js
+++ b/libs/util.js
@@ -22,17 +22,6 @@ const check = (condition, message) => {
 }
 
 /**
- * Print warning message if condition fails but otherwise do nothing.
- * @param {Boolean} condition Condition that must be true.
- * @param {string} message What to say if it isn't.
- */
-const warn = (condition, message) => {
-  if (!condition) {
-    console.warn(message)
-  }
-}
-
-/**
  * Check that a value is numeric.
  * @param {whatever} value What to check.
  */

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -12,12 +12,12 @@ const UserInterface = require('../libs/gui')
  * Testing replacement for a transform (easier constructor).
  */
 class MockTransform extends Transform.base {
-  constructor (name, func, requires, produces, input, output) {
-    super(name, requires, produces, input, output)
+  constructor (species, func, requires, produces, input, output) {
+    super(species, requires, produces, input, output)
     this.func = func
   }
   run = (runner, df) => {
-    runner.appendLog(this.name)
+    runner.appendLog('log', this.species)
     return this.func(runner, df)
   }
 }

--- a/test/test_codegen.js
+++ b/test/test_codegen.js
@@ -187,7 +187,7 @@ describe('expression code generation', () => {
   })
 
   it('generates code for binary arithmetic', (done) => {
-    const expected = [Op.FAMILY, 'exp',
+    const expected = [Op.FAMILY, 'power',
                       [Value.FAMILY, 'number', 1],
                       [Value.FAMILY, 'number', 2]]
     const w = workspace()
@@ -196,7 +196,7 @@ describe('expression code generation', () => {
     const right = w.newBlock('value_number')
     right.setFieldValue(2, 'VALUE')
     const block = w.newBlock('op_arithmetic')
-    block.setFieldValue('exp', 'OP')
+    block.setFieldValue('power', 'OP')
     connect(block, 'LEFT', left)
     connect(block, 'RIGHT', right)
     const actual = getCode(block)
@@ -217,7 +217,7 @@ describe('expression code generation', () => {
   })
 
   it('generates code for comparisons', (done) => {
-    const expected = [Op.FAMILY, 'leq',
+    const expected = [Op.FAMILY, 'lessEqual',
                       [Value.FAMILY, 'number', 1],
                       [Value.FAMILY, 'number', 2]]
     const w = workspace()
@@ -226,7 +226,7 @@ describe('expression code generation', () => {
     const right = w.newBlock('value_number')
     right.setFieldValue(2, 'VALUE')
     const block = w.newBlock('op_compare')
-    block.setFieldValue('leq', 'OP')
+    block.setFieldValue('lessEqual', 'OP')
     connect(block, 'LEFT', left)
     connect(block, 'RIGHT', right)
     const actual = getCode(block)

--- a/test/test_dataframe.js
+++ b/test/test_dataframe.js
@@ -561,7 +561,8 @@ describe('summarize', () => {
 
   it('can summarize a single ungrouped column', (done) => {
     const df = new DataFrame(TWO_ROWS)
-    const result = df.summarize(new Summarize.count('ones'))
+    const summarizer = new Summarize.count('ones')
+    const result = df.summarize(summarizer)
     assert(result.equal(new DataFrame([{ones: 1, tens: 10,
                                         ones_count: 2},
                                        {ones: 2, tens: 20,

--- a/test/test_gui.js
+++ b/test/test_gui.js
@@ -41,7 +41,7 @@ describe('creates the interface object', () => {
     const block = gui.workspace.newBlock('data_colors')
     block.hat = 'cap'
     gui.runProgram()
-    assert.deepEqual(gui.env.log, ['read'],
+    assert.deepEqual(gui.env.log, [['log', 'read colors']],
                      `Program did not run as expected`)
     done()
   })

--- a/test/test_pipeline.js
+++ b/test/test_pipeline.js
@@ -87,7 +87,7 @@ describe('executes pipelines', () => {
   it('executes a pipeline with notification', (done) => {
     const pipeline = new Pipeline(fixture.HEAD, fixture.TAIL_NOTIFY)
     const result = pipeline.run(new Env(INTERFACE.userData))
-    assert.equal(result.name, 'keyword',
+    assert.equal(result.label, 'keyword',
                  `Result should include name`)
     assert(result.data.equal(fixture.TABLE),
            `Result should contain unmodified table`)
@@ -95,10 +95,10 @@ describe('executes pipelines', () => {
   })
 
   it('logs execution', (done) => {
-    const runner = new Env(INTERFACE.userData)
+    const env = new Env(INTERFACE.userData)
     const pipeline = new Pipeline(fixture.HEAD, fixture.MIDDLE, fixture.TAIL)
-    const result = pipeline.run(runner)
-    assert.deepEqual(runner.log, ['head', 'middle', 'tail'],
+    const result = pipeline.run(env)
+    assert.deepEqual(env.log, [['log', 'head'], ['log', 'middle'], ['log', 'tail']],
                      `Transforms not logged`)
     done()
   })

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -201,9 +201,13 @@ describe('executes program', () => {
 
     const env = new Env(INTERFACE.userData)
     program.run(env)
-    assert.equal(env.errors.length, 1,
-                 `No saved error message`)
-    assert(env.errors[0].startsWith('error message'),
+    assert.equal(env.log.length, 2,
+                 `No saved messages`)
+    assert(env.log[0][0] === 'log',
+           `First message should be log message`)
+    assert(env.log[1][0] === 'error',
+           `Second message should be log message`)
+    assert(env.log[1][1].startsWith('error message'),
            `Error message incorrectly formatted`)
     done()
   })
@@ -282,8 +286,8 @@ describe('executes program', () => {
 
     const env = new Env(INTERFACE.userData)
     program.run(env)
-    assert.deepEqual(env.errors, [],
-                     `Should not have an error message`)
+    assert.equal(env.log.length, 6,
+                 `Should have run 6 stages`)
 
     const data = [{alpha_right: 10, beta_right: 10 },
                   {alpha_right: 20, beta_right: 20 }]


### PR DESCRIPTION
Bug fixes to allow log messages to be displayed.
    
1.  Changing names of pulldown elements in blocks to match operation names.
2.  Updating tests.
3.  Adding display of log messages in UI.
    
To do:
    
1.  Give each log message a key.
2.  Use log message type ("log" or "error") to style list elements.

Requires #48.