### PR TITLE
Moving XML configuration out of index.html and into `./blocks/blocks.js`

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -229,7 +229,73 @@ const createBlocks = () => {
   }
 }
 
+// ----------------------------------------------------------------------
+// Configuration of blocks. This is here instead of in the HTML page
+// in order to avoid confusing React.
+// ----------------------------------------------------------------------
+
+const XML_CONFIG = `
+<xml id="toolbox" style="display: none">
+  <category name="data" categorystyle="data">
+    <block type="data_colors"></block>
+    <block type="data_earthquakes"></block>
+    <block type="data_penguins"></block>
+    <block type="data_sequence"></block>
+    <block type="data_user"></block>
+  </category>
+  <category name="transform" categorystyle="transform">
+    <block type="transform_drop"></block>
+    <block type="transform_filter"></block>
+    <block type="transform_groupBy"></block>
+    <block type="transform_mutate"></block>
+    <block type="transform_report"></block>
+    <block type="transform_select"></block>
+    <block type="transform_sort"></block>
+    <block type="transform_summarize"></block>
+    <block type="transform_ungroup"></block>
+    <block type="transform_unique"></block>
+  </category>
+  <category name="plot" categorystyle="plot">
+    <block type="plot_bar"></block>
+    <block type="plot_box"></block>
+    <block type="plot_dot"></block>
+    <block type="plot_histogram"></block>
+    <block type="plot_scatter"></block>
+  </category>
+  <category name="stats" categorystyle="stats">
+    <block type="stats_ttest_one"></block>
+    <block type="stats_ttest_two"></block>
+  </category>
+  <category name="op" categorystyle="op">
+    <block type="op_arithmetic"></block>
+    <block type="op_negate"></block>
+    <block type="op_compare"></block>
+    <block type="op_logical"></block>
+    <block type="op_not"></block>
+    <block type="op_type"></block>
+    <block type="op_convert"></block>
+    <block type="op_datetime"></block>
+    <block type="op_conditional"></block>
+  </category>
+  <category name="value" categorystyle="value">
+    <block type="value_column"></block>
+    <block type="value_datetime"></block>
+    <block type="value_logical"></block>
+    <block type="value_number"></block>
+    <block type="value_text"></block>
+    <block type="value_rownum"></block>
+    <block type="value_exponential"></block>
+    <block type="value_normal"></block>
+    <block type="value_uniform"></block>
+  </category>
+  <category name="combine" categorystyle="combine">
+    <block type="combine_glue"></block>
+    <block type="combine_join"></block>
+  </category>
+</xml>`
+
 module.exports = {
   THEME,
+  XML_CONFIG,
   createBlocks
 }

--- a/index.html
+++ b/index.html
@@ -12,73 +12,13 @@
     <script>
       let ui = null
       window.onload = () => {
-        TidyBlocksUI = tidyblocks.setup('root', 'toolbox')
+        TidyBlocksUI = tidyblocks.setup('root')
       }
     </script>
   </head>
   <body>
     <!-- UI goes here -->
     <div id="root"></div>
-
-    <!-- Blockly toolbox configuration -->
-    <xml id="toolbox" style="display: none">
-      <category name="data" categorystyle="data">
-        <block type="data_colors"></block>
-        <block type="data_earthquakes"></block>
-        <block type="data_penguins"></block>
-        <block type="data_sequence"></block>
-        <block type="data_user"></block>
-      </category>
-      <category name="transform" categorystyle="transform">
-        <block type="transform_drop"></block>
-        <block type="transform_filter"></block>
-        <block type="transform_groupBy"></block>
-        <block type="transform_mutate"></block>
-        <block type="transform_report"></block>
-        <block type="transform_select"></block>
-        <block type="transform_sort"></block>
-        <block type="transform_summarize"></block>
-        <block type="transform_ungroup"></block>
-        <block type="transform_unique"></block>
-      </category>
-      <category name="plot" categorystyle="plot">
-        <block type="plot_bar"></block>
-        <block type="plot_box"></block>
-        <block type="plot_dot"></block>
-        <block type="plot_histogram"></block>
-        <block type="plot_scatter"></block>
-      </category>
-      <category name="stats" categorystyle="stats">
-        <block type="stats_ttest_one"></block>
-        <block type="stats_ttest_two"></block>
-      </category>
-      <category name="op" categorystyle="op">
-        <block type="op_arithmetic"></block>
-        <block type="op_negate"></block>
-        <block type="op_compare"></block>
-        <block type="op_logical"></block>
-        <block type="op_not"></block>
-        <block type="op_type"></block>
-        <block type="op_convert"></block>
-        <block type="op_datetime"></block>
-        <block type="op_conditional"></block>
-      </category>
-      <category name="value" categorystyle="value">
-        <block type="value_column"></block>
-        <block type="value_datetime"></block>
-        <block type="value_logical"></block>
-        <block type="value_number"></block>
-        <block type="value_text"></block>
-        <block type="value_rownum"></block>
-        <block type="value_exponential"></block>
-        <block type="value_normal"></block>
-        <block type="value_uniform"></block>
-      </category>
-      <category name="combine" categorystyle="combine">
-        <block type="combine_glue"></block>
-        <block type="combine_join"></block>
-      </category>
-    </xml>
 
     <!-- Vega-Lite -->
     <script src="https://cdn.jsdelivr.net/npm/vega@5.9.0"></script>

--- a/index.js
+++ b/index.js
@@ -18,20 +18,12 @@ class ReactInterface extends UserInterface {
   /**
    * Build user interface object.
    * @param rootId HTML ID of root element.
-   * @param toolboxId HTML ID of 'xml' element containing toolbox spec.
    */
-  constructor (rootId, toolboxId) {
+  constructor (rootId) {
     super()
 
     // Create the Blockly settings.
-    const toolbox = document.getElementById(toolboxId)
-    assert(toolbox,
-           `No toolbox found with ID ${toolboxId}`)
-    const settings = this._createSettings(toolbox)
-
-    // Get a string of the toolbox XML, this'll get parsed within the React app.
-    const serializer = new XMLSerializer()
-    const toolboxString = serializer.serializeToString(toolbox)
+    const settings = this._createSettings()
 
     // Create an environment so that the React app can get at the pre-loaded
     // datasets.  Make sure the environment points back at the UI object so that
@@ -40,7 +32,7 @@ class ReactInterface extends UserInterface {
 
     // Render React, saving the React app.
     this.app = ReactDOM.render(
-      <TidyBlocksApp settings={settings} toolbox={toolboxString} initialEnv={env}/>,
+      <TidyBlocksApp settings={settings} toolbox={blocks.XML_CONFIG} initialEnv={env}/>,
       document.getElementById(rootId)
     )
 
@@ -62,9 +54,8 @@ class ReactInterface extends UserInterface {
    * @param toolboxId XML element containing toolbox spec.
    * @returns JSON settings object.
    */
-  _createSettings (toolbox) {
+  _createSettings () {
     return {
-      toolbox: toolbox,
       theme: blocks.THEME,
       zoom: {
         controls: true,


### PR DESCRIPTION
Doing this puts the block configuration with the blocks, gets rid of an element in `index.html` that React doesn't understand, and simplifies the logic of the setup code (no need to pass in the XML element ID, parse it, etc.).

Closes #64.