### PR TITLE
Fixing bug in execution cycle discovered while formatting log messages.

### DIFF
--- a/libs/env.js
+++ b/libs/env.js
@@ -3,6 +3,8 @@
 const util = require('./util')
 const DataFrame = require('./dataframe')
 
+const LOG_LEVELS = new Set(['log', 'warn', 'error'])
+
 /**
  * Runtime environment.
  * @param userData Datasets loaded by the user (keyed by label).
@@ -48,8 +50,9 @@ class Env {
                `Require non-empty string label for result`)
     util.check(data instanceof DataFrame,
                `Require dataframe for data`)
-    util.check(!this.results.has(label),
-               `Result with label ${label} already exists`)
+    if (this.results.has(label)) {
+      this.appendLog('warn', `Result with label ${label} already exists`)
+    }
     this.results.set(label, data)
   }
 
@@ -73,8 +76,9 @@ class Env {
   setPlot (label, spec) {
     util.check(label && (typeof label === 'string'),
                `Require non-empty string as plot label`)
-    util.check(!this.plots.has(label),
-               `Duplicate plot label ${label}`)
+    if (this.plots.has(label)) {
+      this.appendLog('warn', `Plot with label ${label} already exists`)
+    }
     this.plots.set(label, spec)
   }
 
@@ -93,14 +97,15 @@ class Env {
   /**
    * Store a statistical result.
    * @param label Name of result to get.
-   * @param {Object} result Result to store.
+   * @param {Object} stats Result to store.
    */
-  setStats (label, spec) {
+  setStats (label, stats) {
     util.check(label && (typeof label === 'string'),
                `Require non-empty string as stats label`)
-    util.check(!this.stats.has(label),
-               `Duplicate stats label ${label}`)
-    this.stats.set(label, spec)
+    if (this.stats.has(label)) {
+      this.appendLog('warn', `Statistics with label ${label} already exists`)
+    }
+    this.stats.set(label, stats)
   }
 
   /**
@@ -109,8 +114,8 @@ class Env {
    * @param {string} message To save.
    */
   appendLog (level, message) {
-    util.check(level && (typeof level === 'string') && ['log', 'error'].includes(level),
-               `Expected either "log" or "error" for level, not "${level}"`)
+    util.check(level && (typeof level === 'string') && LOG_LEVELS.has(level),
+               `Invalid or unknown log level "${level}"`)
     this.log.push([level, message])
   }
 }

--- a/libs/pipeline.js
+++ b/libs/pipeline.js
@@ -35,8 +35,8 @@ class Pipeline {
 
   /**
    * Run this pipeline.
-   * @param {Env} env The runtime environment.
-   * @returns The result of the final transform.
+   * @param {Env} env The runtime environment. This is filled with results,
+   * statistics, and plots as a side effect of running certain blocks.
    */
   run (env) {
     util.check(Array.isArray(this.transforms) &&
@@ -53,12 +53,6 @@ class Pipeline {
     let data = null
     for (const transform of this.transforms) {
       data = transform.run(env, data)
-    }
-
-    const last = this.transforms.slice(-1)[0]
-    return {
-      label: last.produces,
-      data: data
     }
   }
 }

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -17,19 +17,16 @@ class TransformBase {
   /**
    * @param {string} species What this transform is called.
    * @param {string[]} requires What datasets are required before this can run?
-   * @param {string} produces What dataset does this transform produce?
    * @param {Boolean} input Does this transform require input?
-   * @param {Boolean} output Does this transform produce input?
+   * @param {Boolean} output Does this transform produce output?
    */
-  constructor (species, requires, produces, input, output) {
+  constructor (species, requires, input, output) {
     util.check(species && (typeof species === 'string') &&
                Array.isArray(requires) &&
-               requires.every(x => (typeof x === 'string')) &&
-               ((produces === null) || (typeof produces === 'string')),
+               requires.every(x => (typeof x === 'string')),
                `Bad parameters to constructor`)
     this.species = species
     this.requires = requires
-    this.produces = produces
     this.input = input
     this.output = output
   }
@@ -61,7 +58,7 @@ class TransformData extends TransformBase {
   constructor (name) {
     util.check(typeof name === 'string',
                `Expected string`)
-    super('read', [], null, false, true)
+    super('read', [], false, true)
     this.name = name
   }
 
@@ -86,7 +83,7 @@ class TransformDrop extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('drop', [], null, true, true)
+    super('drop', [], true, true)
     this.columns = columns
   }
 
@@ -108,7 +105,7 @@ class TransformFilter extends TransformBase {
   constructor (expr) {
     util.check(expr instanceof ExprBase,
                `Expected expression`)
-    super('filter', [], null, true, true)
+    super('filter', [], true, true)
     this.expr = expr
   }
 
@@ -131,7 +128,7 @@ class TransformGroupBy extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('groupBy', [], null, true, true)
+    super('groupBy', [], true, true)
     this.columns = columns
   }
 
@@ -154,7 +151,7 @@ class TransformGroupBy extends TransformBase {
  */
 class TransformJoin extends TransformBase {
   constructor (leftName, leftCol, rightName, rightCol) {
-    super('join', [leftName, rightName], null, false, true)
+    super('join', [leftName, rightName], false, true)
     this.leftName = leftName
     this.leftCol = leftCol
     this.rightName = rightName
@@ -191,7 +188,7 @@ class TransformMutate extends TransformBase {
                `Expected string as new name`)
     util.check(expr instanceof ExprBase,
                `Expected expression`)
-    super('mutate', [], null, true, true)
+    super('mutate', [], true, true)
     this.newName = newName
     this.expr = expr
   }
@@ -216,7 +213,7 @@ class TransformReport extends TransformBase {
   constructor (label) {
     util.check(typeof label === 'string',
                `Expected string`)
-    super('report', [], label, true, false)
+    super('report', [], true, true)
     this.label = label
   }
 
@@ -227,6 +224,7 @@ class TransformReport extends TransformBase {
 
   run (env, df) {
     env.appendLog('log', `${this.species} ${this.label}`)
+    env.setResult(this.label, df)
     return df
   }
 }
@@ -239,7 +237,7 @@ class TransformSelect extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('select', [], null, true, true)
+    super('select', [], true, true)
     this.columns = columns
   }
 
@@ -262,7 +260,7 @@ class TransformSequence extends TransformBase {
   constructor (newName, limit) {
     util.check(typeof newName === 'string',
                `Expected string as new name`)
-    super('sequence', [], null, true, true)
+    super('sequence', [], true, true)
     this.newName = newName
     this.limit = limit
   }
@@ -297,7 +295,7 @@ class TransformSort extends TransformBase {
                `Expected array of columns`)
     util.check(typeof reverse === 'boolean',
                `Expected Boolean`)
-    super('sort', [], null, true, true)
+    super('sort', [], true, true)
     this.columns = columns
     this.reverse = reverse
   }
@@ -325,7 +323,7 @@ class TransformSummarize extends TransformBase {
                `Unknown summarization operation ${action}`)
     util.check(typeof column === 'string',
                `Expected string as column name`)
-    super('summarize', [], null, true, true)
+    super('summarize', [], true, true)
     this.action = action
     this.column = column
   }
@@ -347,7 +345,7 @@ class TransformSummarize extends TransformBase {
  */
 class TransformUngroup extends TransformBase {
   constructor () {
-    super('ungroup', [], null, true, true)
+    super('ungroup', [], true, true)
   }
 
   run (env, df) {
@@ -364,7 +362,7 @@ class TransformUnique extends TransformBase {
   constructor (columns) {
     util.check(Array.isArray(columns),
                `Expected array of columns`)
-    super('unique', [], null, true, true)
+    super('unique', [], true, true)
     this.columns = columns
   }
 
@@ -387,7 +385,7 @@ class TransformPlot extends TransformBase {
   constructor (name, label, spec, fillin) {
     util.check(label && (typeof label === 'string'),
                `Must provide non-empty label`)
-    super(name, [], null, true, false)
+    super(name, [], true, true)
     this.label = label
     this.spec = Object.assign({}, spec, fillin, {name})
   }
@@ -396,6 +394,7 @@ class TransformPlot extends TransformBase {
     env.appendLog('log', `${this.species} ${this.label}`)
     this.spec.data.values = df.data
     env.setPlot(this.label, this.spec)
+    return df
   }
 }
 
@@ -541,7 +540,7 @@ class TransformScatter extends TransformPlot {
  */
 class TransformTTestOneSample extends TransformBase {
   constructor (label, colName, mean) {
-    super('ttest_one', [], null, true, false)
+    super('ttest_one', [], true, true)
     this.label = label
     this.colName = colName
     this.mean = mean
@@ -564,7 +563,7 @@ class TransformTTestOneSample extends TransformBase {
  */
 class TransformTTestPaired extends TransformBase {
   constructor (label, labelCol, valueCol) {
-    super('ttest_two', [], null, true, false)
+    super('ttest_two', [], true, true)
     this.label = label
     this.labelCol = labelCol
     this.valueCol = valueCol

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -444,14 +444,14 @@ export class TidyBlocksApp extends React.Component {
   render () {
     const classes = withStyles(Tabs)
     const tabClasses = withStyles(Tab)
-    const logMessages = (!this.state.logMessages)
-          ? <li className="tbLog" key="message-0">No messages</li>
-          : this.state.logMessages.map((msg, i) => {
-              const key = `message-${i}`
-              const cls = (msg[0] === 'log') ? 'tbLog' : 'tbError'
-              return (<li className={cls} key={key}><code>{msg[1]}</code></li>)
-            })
-    const logMessageList = <ul>{logMessages}</ul>
+    const logMessages = (!this.state.logMessages) ?
+          <li className="tb-log" key="message-0">No messages</li> :
+          this.state.logMessages.map((msg, i) => {
+            const key = `message-${i}`
+            const cls = `tb-${msg[0]}`
+            return (<li className={cls} key={key}><code>{msg[1]}</code></li>)
+          })
+    const logMessageList = <ul className="tb-messages">{logMessages}</ul>
 
     return (
       <div className="splitPaneWrapper">

--- a/static/sass/base.scss
+++ b/static/sass/base.scss
@@ -7,51 +7,51 @@
 @import 'jekyll-site';
 @import 'jekyll-trac';
 
-body{
+body {
   margin: 0px;
 }
 
-.sectionTitle{
+.sectionTitle {
   font-size: 24px;
   text-align: center;
 }
 
 // Pane styling.
-.splitPaneWrapper{
+.splitPaneWrapper {
   height: 90%
 }
 
-.topRightPane{
+.topRightPane {
   width: 100%;
   height: 100%;
   background: #fff;
 }
 
-.bottomRightPane{
+.bottomRightPane {
   width: 100%;
   height: 100%;
   background: #fff;
 }
 
-.splitterBottomPane{
+.splitterBottomPane {
   z-index: 3;
 }
 
 // Plot Styling.
-#plotOutput{
+#plotOutput {
   display: block;
   margin-top: 5px;
   margin-left: 0px;
   margin-right: 0px;
 }
 
-.plotWrapper{
+.plotWrapper {
   margin-left: 15px;
   margin-right: 15px;
   margin-bottom: 15px;
 }
 
-.dataWrapper{
+.dataWrapper {
   margin: 10px;
 }
 
@@ -63,14 +63,14 @@ body{
   width: 100%;
 }
 
-.sourceSelect{
+.sourceSelect {
   padding: 2px;
   font-size: 14px;
   font-family: "Roboto";
   font-weight: 500;
 }
 
-.sourceSelectInner__control{
+.sourceSelectInner__control {
   padding: 2px;
 }
 

--- a/static/sass/jekyll-site.scss
+++ b/static/sass/jekyll-site.scss
@@ -1,4 +1,4 @@
-.jekyllBody{
+.jekyllBody {
   font-family: "Helvetica Neue", Helvetica;
   font-size: 12pt;
   width: 70rem;

--- a/static/sass/material-ui-custom.scss
+++ b/static/sass/material-ui-custom.scss
@@ -1,24 +1,31 @@
-.MuiBox-root{
+.MuiBox-root {
   padding: 5px !important;
 }
 
-.MuiDrawer-paper{
+.MuiDrawer-paper {
   width: 400px;
 }
 
-.MuiTypography-h6{
+.MuiTypography-h6 {
   font-size: 1.2rem !important;
 }
 
-.tbMenuButton{
+.tbMenuButton {
   font-size: 10px;
 }
 
-.tbToolbar{
+.tbToolbar {
   min-height: 40px !important;
 }
 
-li.tbError {
+li.tb-log {
+}
+
+li.tb-warn {
+  font-style: italic;
+}
+
+li.tb-error {
   font-weight: bold;
   font-style: italic;
 }

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -12,8 +12,8 @@ const UserInterface = require('../libs/gui')
  * Testing replacement for a transform (easier constructor).
  */
 class MockTransform extends Transform.base {
-  constructor (species, func, requires, produces, input, output) {
-    super(species, requires, produces, input, output)
+  constructor (species, func, requires, input, output) {
+    super(species, requires, input, output)
     this.func = func
   }
   run = (runner, df) => {
@@ -42,8 +42,6 @@ const pass = (runner, df) => df
 const TABLE = new DataFrame([{left: 1, right: 10},
                              {left: 2, right: 20}])
 
-const HEAD = new MockTransform('head', (runner, df) => TABLE,
-                               [], null, false, true)
 /*
  * Date testing.
  */
@@ -95,10 +93,10 @@ module.exports = {
   ],
   COLORS: require('../data/colors'),
   TABLE,
-  HEAD,
-  MIDDLE: new MockTransform('middle', pass, [], null, true, true),
-  TAIL: new MockTransform('tail', pass, [], null, true, false),
-  TAIL_REPORT: new MockTransform('tailReport', pass, [], 'keyword', true, false),
+  HEAD: new MockTransform('head', (runner, df) => TABLE, [], false, true),
+  MIDDLE: new MockTransform('middle', pass, [], true, true),
+  REPORT: new Transform.report('keyword'),
+  NO_OUTPUT: new MockTransform('no_output', pass, [], true, false),
   pass,
   TestInterface
 }

--- a/test/test_program.js
+++ b/test/test_program.js
@@ -48,27 +48,21 @@ describe('data management', () => {
 describe('executes program', () => {
   it('requires a name and some data when notifying', (done) => {
     const program = new Program()
-    assert.throws(() => program.notify('name', new DataFrame([])),
+    assert.throws(() => program.notify('name'),
                   Error,
                   `Should require environment when doing notification`)
     program.env = new Env(INTERFACE)
-    assert.throws(() => program.notify('', new DataFrame([])),
+    assert.throws(() => program.notify(''),
                   Error,
                   `Should require notification name`)
-    assert.throws(() => program.notify('name', new Date()),
-                  Error,
-                  `Should require dataframe`)
     done()
   })
 
   it('can notify when nothing is waiting', (done) => {
     const program = new Program()
-    const df = new DataFrame([])
     const env = new Env(INTERFACE)
     program.env = env
-    program.notify('name', df)
-    assert(df.equal(env.getData('name')),
-           `Should be able to get data after notifying`)
+    program.notify('name')
     done()
   })
 
@@ -127,7 +121,8 @@ describe('executes program', () => {
                  `Should have one non-runnable pipeline`)
 
     program.env = new Env(INTERFACE)
-    program.notify('first', df)
+    program.env.setResult('first', df)
+    program.notify('first')
     assert.equal(program.waiting.size, 0,
                  `Waiting set should be empty`)
     assert.equal(program.queue.length, 1,
@@ -143,21 +138,20 @@ describe('executes program', () => {
     const requires = ['first', 'second', 'third']
     const last = new fixture.MockTransform('last', fixture.pass, requires, null, true, true)
     const lastPipe = new Pipeline(last)
-    const df = new DataFrame([])
 
     program.register(lastPipe)
     assert.equal(program.waiting.size, 1,
                  `Should have one non-runnable pipeline`)
 
     for (const name of ['third', 'second']) {
-      program.notify(name, df)
+      program.notify(name)
       assert(program.waiting.size > 0,
              `Pipeline should still be waiting`)
       assert.equal(program.queue.length, 0,
                    `Nothing should be runnable`)
     }
 
-    program.notify('first', df)
+    program.notify('first')
     assert.equal(program.waiting.size, 0,
                  `Nothing should be waiting`)
     assert.equal(program.queue.length, 1,
@@ -172,7 +166,6 @@ describe('executes program', () => {
     program.env = new Env(INTERFACE)
     const leftTransform = new fixture.MockTransform('left', fixture.pass, ['something'], null, true, true)
     const leftPipe = new Pipeline(leftTransform)
-    const df = new DataFrame([])
     const rightTransform = new fixture.MockTransform('right', fixture.pass, ['else'], null, true, true)
     const rightPipe = new Pipeline(rightTransform)
 
@@ -181,7 +174,7 @@ describe('executes program', () => {
     assert.equal(program.waiting.size, 2,
                  `Should have two non-runnable pipelines`)
 
-    program.notify('else', df)
+    program.notify('else')
     assert.equal(program.waiting.size, 1,
                  `Should still have one waiting pipeline`)
     assert.equal(program.queue.length, 1,
@@ -214,9 +207,8 @@ describe('executes program', () => {
 
   it('runs a single pipeline with no dependencies that does not notify', (done) => {
     const program = new Program()
-    const pipeline = new Pipeline(fixture.HEAD, fixture.TAIL)
+    const pipeline = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
     program.register(pipeline)
-
     const env = new Env(INTERFACE)
     program.run(env)
     assert.equal(env.results.size, 0,
@@ -226,7 +218,7 @@ describe('executes program', () => {
 
   it('runs a single pipeline with no dependencies that reports', (done) => {
     const program = new Program()
-    const pipeline = new Pipeline(fixture.HEAD, fixture.TAIL_REPORT)
+    const pipeline = new Pipeline(fixture.HEAD, fixture.REPORT)
     program.register(pipeline)
 
     const env = new Env(INTERFACE)
@@ -238,17 +230,13 @@ describe('executes program', () => {
 
   it('runs two independent pipelines in some order', (done) => {
     const program = new Program()
-    const tailLocal = new fixture.MockTransform('tailLocal', fixture.pass, [], 'local', true, false)
-    const pipeLocal = new Pipeline(fixture.HEAD, tailLocal)
-    program.register(pipeLocal)
-    const pipeReport = new Pipeline(fixture.HEAD, fixture.TAIL_REPORT)
+    const pipeQuiet = new Pipeline(fixture.HEAD, fixture.NO_OUTPUT)
+    program.register(pipeQuiet)
+    const pipeReport = new Pipeline(fixture.HEAD, fixture.REPORT)
     program.register(pipeReport)
-
     const env = new Env(INTERFACE)
     program.run(env)
     assert(env.getData('keyword').equal(fixture.TABLE),
-           `Missing or incorrect table`)
-    assert(env.getData('local').equal(fixture.TABLE),
            `Missing or incorrect table`)
     done()
   })
@@ -258,31 +246,30 @@ describe('executes program', () => {
     const headRequire = new fixture.MockTransform('headRequire',
                                       (runner, df) => fixture.TABLE,
                                       ['keyword'], null, false, true)
-    const tailLocal = new fixture.MockTransform('tailLocal', fixture.pass,
-                                    [], 'local', true, false)
-    const pipeReport = new Pipeline(fixture.HEAD, fixture.TAIL_REPORT)
-    const pipeRequireLocal = new Pipeline(headRequire, tailLocal)
+    const pipeRequire = new Pipeline(headRequire)
+    program.register(pipeRequire)
+
+    const pipeReport = new Pipeline(fixture.HEAD, fixture.REPORT)
     program.register(pipeReport)
-    program.register(pipeRequireLocal)
 
     const env = new Env(INTERFACE)
     program.run(env)
     assert(env.getData('keyword').equal(fixture.TABLE),
            `Missing or incorrect table`)
-    assert(env.getData('local').equal(fixture.TABLE),
-           `Missing or incorrect table`)
+    assert.deepEqual(env.log, [['log', 'head'], ['log', 'report keyword'], ['log', 'headRequire']],
+                     `Expected to see report in log`)
     done()
   })
 
   it('handles a join correctly', (done) => {
     const program = new Program()
-    const tailAlpha = new fixture.MockTransform('tailAlpha', fixture.pass, [], 'alpha', true, false)
-    const tailBeta = new fixture.MockTransform('tailBeta', fixture.pass, [], 'beta', true, false)
+    const reportAlpha = new Transform.report('alpha')
+    const reportBeta = new Transform.report('beta')
     const join = new Transform.join('alpha', 'left', 'beta', 'left')
 
-    program.register(new Pipeline(fixture.HEAD, tailAlpha))
-    program.register(new Pipeline(fixture.HEAD, tailBeta))
-    program.register(new Pipeline(join, fixture.TAIL_REPORT))
+    program.register(new Pipeline(fixture.HEAD, reportAlpha))
+    program.register(new Pipeline(fixture.HEAD, reportBeta))
+    program.register(new Pipeline(join, fixture.REPORT))
 
     const env = new Env(INTERFACE)
     program.run(env)

--- a/test/test_transform.js
+++ b/test/test_transform.js
@@ -86,10 +86,15 @@ describe('build dataframe operations', () => {
     const transform = new Transform.report('answer')
     const input = new DataFrame(fixture.NAMES)
     const result = transform.run(env, input)
-    assert(result.equal(new DataFrame(fixture.NAMES)),
+    const expected = new DataFrame(fixture.NAMES)
+    assert(result instanceof DataFrame,
+           `Expected DataFrame as result`)
+    assert(result.equal(expected),
            `Should not modify data`)
-    assert.equal(transform.produces, 'answer',
-                 `Wrong name`)
+    assert(env.results.has('answer'),
+           `Should have an answer recorded`)
+    assert(env.results.get('answer').equal(expected),
+           `Wrong result recorded`)
     done()
   })
 


### PR DESCRIPTION
1.  Define `li.tb-log`, `li.tb-warn`, and `li.tb-error` styles for formatting three levels of log message.
2.  Modify `libs/ui/ui.jsx` to add these classes to log messages when displaying.
3.  Add spacing before `{` in various CSS classes.
4.  Add checks in `Env` that produce warning messages when results, statistics, or plots with duplicate names are registered.

While trying to test this, discovered a bug in the pipeline execution cycle.

1.  Cleaner separation between registering results and notifying pipelines they are ready to run in `libs/pipeline.js` and `libs/program.js`.
2.  Modify all transforms so that their `.run` method returns a dataframe.
3.  Removed parameter from transform constructor that was used to say what result it produced, since `TransformReport` now reports results as a side effect during execution.
4.  Updated fixtures and tests to match.