### PR TITLE
The ability to save properly styled svgs.

### DIFF
--- a/libs/ui/menuBar.jsx
+++ b/libs/ui/menuBar.jsx
@@ -45,7 +45,7 @@ class SaveMenuItems extends React.Component{
   render () {
     return (
       <React.Fragment>
-        <Link id="downloadWorkspace">
+        <Link >
           <MenuItem onClick={() => this.handleClick(this.props.saveWorkspace)}>
             Save Workspace
           </MenuItem>
@@ -53,6 +53,10 @@ class SaveMenuItems extends React.Component{
         <Link>
           <MenuItem onClick={() => this.handleClick(this.props.saveData)}>
             Save Data</MenuItem>
+        </Link>
+        <Link>
+          <MenuItem onClick={() => this.handleClick(this.props.saveSvg)}>
+            Save Svg</MenuItem>
         </Link>
       </React.Fragment>
     )
@@ -106,7 +110,7 @@ function MenuItemsButton ({name, icon, handleClick}) {
 }
 
 // Create the Save items for the top TidyBlocks bar.
-function TidyBlocksSaveMenuItems({name, icon, menuItems, saveWorkspace, saveData}) {
+function TidyBlocksSaveMenuItems({name, icon, menuItems, saveWorkspace, saveData, saveSvg}) {
   const [anchorEl, setAnchorEl] = React.useState(null)
   const open = Boolean(anchorEl)
   const handleClick = (event) => {
@@ -129,7 +133,8 @@ function TidyBlocksSaveMenuItems({name, icon, menuItems, saveWorkspace, saveData
         <SaveMenuItems
           onClose={handleClose}
           saveWorkspace={saveWorkspace}
-          saveData={saveData}/>
+          saveData={saveData}
+          saveSvg={saveSvg}/>
       </Menu>
     </div>
   )
@@ -196,6 +201,7 @@ export class MenuBar extends React.Component{
               <TidyBlocksSaveMenuItems name="Save"
                 saveWorkspace={this.props.saveWorkspace}
                 saveData={this.props.saveData}
+                saveSvg={this.props.saveSvg}
                 icon={<SaveIcon className="menuIcon" />}/>
               <TidyBlocksHelpMenuItems edge="start" name="Help"
                 icon={<HelpIcon className="menuIcon" />}/>

--- a/libs/ui/saveDialog.jsx
+++ b/libs/ui/saveDialog.jsx
@@ -175,3 +175,78 @@ export class SaveWorkspaceFormDialog extends React.Component{
     )
   }
 }
+
+export class SaveSvgFormDialog extends React.Component{
+  constructor(props) {
+    super(props)
+    const dateObj = new Date()
+    const month = dateObj.getUTCMonth() + 1
+    const day = dateObj.getUTCDate()
+    const year = dateObj.getUTCFullYear()
+    const filename = 'svg_' + year + '_' + month + '_' + day + '.svg'
+
+    this.state = {
+      open: false,
+      filename: filename,
+      linkId: 'downloadSvg',
+      title: 'Save Svg',
+      contentText: 'Enter the name for your svg file.'
+    }
+    this.handleClickOpen = this.handleClickOpen.bind(this)
+    this.handleClose = this.handleClose.bind(this)
+    this.handleDownload = this.handleDownload.bind(this)
+    this.handleFilenameChange = this.handleFilenameChange.bind(this)
+  }
+
+  handleClickOpen () {
+    this.setState({open: true})
+  }
+
+  handleClose () {
+    this.setState({open: false})
+  }
+
+  handleFilenameChange (evt) {
+    const value = evt.target.value
+    this.setState({ filename: value })
+  }
+
+  handleDownload (workspace){
+    const canvas = workspace.svgBlockCanvas_.cloneNode(true)
+    canvas.removeAttribute("transform");
+    let themeCss = document.getElementById("blockly-renderer-style-geras-tidyblocks").innerHTML
+    // Theme name isn't inserted on our pulled svg so we remove it.
+    themeCss = themeCss.replace(/.geras-renderer.tidyblocks-theme/g, '')
+    // Default blockly css.
+    let blocklyCss = document.getElementById("blockly-common-style").innerHTML
+    const css = `<defs><style type="text/css">` + themeCss + blocklyCss + `</style></defs>`
+    const bboxElement = document.getElementsByClassName("blocklyBlockCanvas")[0];
+    const bbox = bboxElement.getBBox();
+    const content = new XMLSerializer().serializeToString(canvas);
+    const xml = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${
+      bbox.width}" height="${bbox.height}" viewBox=" ${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}">${
+      css}">${content}</svg>`
+    const blob = new Blob([xml])
+    const link = document.getElementById('downloadSvg')
+    link.setAttribute('href', URL.createObjectURL(blob))
+    link.setAttribute('download', this.state.filename)
+    this.handleClose()
+  }
+
+  render () {
+    return (
+      <div>
+        <SaveDialog
+          open={this.state.open}
+          title={this.state.title}
+          handleClose={this.handleClose}
+          handleDownload={this.handleDownload}
+          handleFilenameChange={this.handleFilenameChange}
+          contentText={this.state.contentText}
+          linkId={this.state.linkId}
+          filename={this.state.filename}
+          data={this.props.data}/>
+      </div>
+    )
+  }
+}

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -23,7 +23,7 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faWindowMaximize, faWindowMinimize, faWindowRestore } from '@fortawesome/free-solid-svg-icons'
 import { MenuBar } from './menuBar.jsx'
-import { SaveCsvFormDialog, SaveWorkspaceFormDialog } from './csvDialog.jsx'
+import { SaveCsvFormDialog, SaveWorkspaceFormDialog, SaveSvgFormDialog } from './saveDialog.jsx'
 import { DataTabSelect, StatsTabSelect, PlotTabSelect} from './select.jsx'
 
 const TAB_HEIGHT = '34px'
@@ -163,6 +163,7 @@ export class TidyBlocksApp extends React.Component {
     this.csvFileUploader = React.createRef()
     this.saveCsvNameDialog = React.createRef()
     this.saveWorkspaceDialog = React.createRef()
+    this.saveSvgDialog = React.createRef()
 
     // Get the initial environment so that we can pre-populate the datasets.
     const initialEnv = props.initialEnv
@@ -215,6 +216,7 @@ export class TidyBlocksApp extends React.Component {
     this.updateLogMessages = this.updateLogMessages.bind(this)
     this.saveWorkspace = this.saveWorkspace.bind(this)
     this.saveData = this.saveData.bind(this)
+    this.saveSvg = this.saveSvg.bind(this)
     this.maximizePanel = this.maximizePanel.bind(this)
     this.minimizePanel = this.minimizePanel.bind(this)
     this.restorePanel = this.restorePanel.bind(this)
@@ -393,7 +395,6 @@ export class TidyBlocksApp extends React.Component {
   }
 
   runProgram () {
-    console.log(this.blocklyRef.current.workspace.state.workspace.scale)
     TidyBlocksUI.runProgram()
     const env = TidyBlocksUI.env
     this.updateDataInformation(env)
@@ -531,6 +532,12 @@ export class TidyBlocksApp extends React.Component {
     this.saveWorkspaceDialog.current.handleClickOpen()
   }
 
+  // Saves the svg on the Blockly workspace to a file.
+  saveSvg(){
+    this.saveSvgDialog.current.handleClickOpen()
+  }
+
+
   // Calls the file upload input.
   loadWorkspaceClick () {
     this.refs.workspaceFileUploader.click()
@@ -588,13 +595,18 @@ export class TidyBlocksApp extends React.Component {
         <MuiThemeProvider theme={theme}>
           <SaveCsvFormDialog ref={this.saveCsvNameDialog} data={this.state.data}/>
           { this.blocklyRef.current &&
-            <SaveWorkspaceFormDialog ref={this.saveWorkspaceDialog} data={this.getWorkspace().state.workspace}/>
+            <>
+              <SaveWorkspaceFormDialog ref={this.saveWorkspaceDialog} data={this.getWorkspace().state.workspace}/>
+              <SaveSvgFormDialog ref={this.saveSvgDialog} data={this.getWorkspace().state.workspace}/>
+            </>
           }
+
           <MenuBar runProgram={this.runProgram}
             loadCsvClick={this.loadCsvClick}
             loadWorkspaceClick={this.loadWorkspaceClick}
             saveWorkspace={this.saveWorkspace}
-            saveData={this.saveData}/>
+            saveData={this.saveData}
+            saveSvg={this.saveSvg}/>
           <input type="file" id="workspaceFile" ref="workspaceFileUploader"
             onChange={this.loadWorkspace}
             style={{display: "none"}}/>


### PR DESCRIPTION
We can save SVGs now. Will probably move this to being some admin only tool, but for now it's in the save menu.

Note: Currently it'll include all the css for each download. If you're going to embed multiple svgs on a page maybe it makes sense to pull that out, and just get you a single css file you can include on the documentation page?

