### PR TITLE
Getting tests and style checks to pass

### DIFF
--- a/blocks/helpers.js
+++ b/blocks/helpers.js
@@ -21,8 +21,11 @@ const formatMultipleColumnNames = (raw) => {
  * sub-block is missing.
  */
 const valueToCode = (block, label, order) => {
-  const raw = Blockly.TidyBlocks.valueToCode(block, label, order)
-  return raw ? raw : '["@value", "absent"]'
+  let raw = Blockly.TidyBlocks.valueToCode(block, label, order)
+  if (!raw) {
+    raw = '["@value", "absent"]'
+  }
+  return raw
 }
 
 module.exports = {

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -145,8 +145,8 @@ const setup = () => {
           text: 'color'
         },
         {
-          type: "field_checkbox",
-          name: "REGRESSION",
+          type: 'field_checkbox',
+          name: 'REGRESSION',
           checked: false
         }
       ],

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const assert = require('assert')
-const ReactDOM = require('react-dom')
 const React = require('react')
+const ReactDOM = require('react-dom')
 const Blockly = require('blockly/blockly_compressed')
 
 const blocks = require('./blocks/blocks')

--- a/libs/op.js
+++ b/libs/op.js
@@ -50,7 +50,7 @@ class OpNot extends OpNegationBase {
 
   run (row, i) {
     const value = this.arg.run(row, i)
-    return (value === util.MISSING) ? util.MISSING : ((!value) ? true : false)
+    return (value === util.MISSING) ? util.MISSING : !util.makeBoolean(value)
   }
 }
 
@@ -172,9 +172,7 @@ class OpToLogical extends OpConvertBase {
 
   run (row, i) {
     const value = this.arg.run(row, i)
-    return (value === util.MISSING)
-      ? util.MISSING
-      : (value ? true : false)
+    return (value === util.MISSING) ? util.MISSING : util.makeBoolean(value)
   }
 }
 

--- a/libs/program.js
+++ b/libs/program.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const util = require('./util')
-const DataFrame = require('./dataframe')
 const Env = require('./env')
 const Pipeline = require('./pipeline')
 

--- a/libs/transform.js
+++ b/libs/transform.js
@@ -509,48 +509,48 @@ class TransformHistogram extends TransformPlot {
  * @param {string} color Which column to use for color (if any).
  */
 class TransformScatter extends TransformPlot {
-  constructor(label, axisX, axisY, color, lm) {
+  constructor (label, axisX, axisY, color, lm) {
     util.check(axisX && (typeof axisX === 'string') &&
-      axisY && (typeof axisY === 'string'),
-      `Must provide non-empty strings for axes`)
+               axisY && (typeof axisY === 'string'),
+               `Must provide non-empty strings for axes`)
     util.check((color === null) ||
-      ((typeof color === 'string') && color),
-      `Must provide null or non-empty string for color`)
+               ((typeof color === 'string') && color),
+               `Must provide null or non-empty string for color`)
 
     const spec = {
-      data: { values: null },
+      data: {values: null},
       layer: [
         {
-          mark: { type: "point", filled: true },
+          mark: {type: 'point', filled: true},
           encoding: {
-            x: { field: axisX, type: "quantitative" },
-            y: { field: axisY, type: "quantitative" }
+            x: {field: axisX, type: 'quantitative'},
+            y: {field: axisY, type: 'quantitative'}
           }
         }
       ]
     }
     if (lm) {
       spec.layer[1] = {
-        mark: { type: "line", color: "firebrick" },
-        transform: [{ regression: axisY, on: axisX }],
+        mark: {type: 'line', color: 'firebrick'},
+        transform: [{regression: axisY, on: axisX}],
         encoding: {
-          x: { field: axisX, type: "quantitative" },
-          y: { field: axisY, type: "quantitative" }
+          x: {field: axisX, type: 'quantitative'},
+          y: {field: axisY, type: 'quantitative'}
         }
       }
       spec.layer[2] = {
-          transform: [ 
-            { regression: axisY, on: axisX, params: true },
-            { calculate: "'R²: '+format(datum.rSquared, '.2f')", as: "R2"}
-          ],
-          mark: { type: "text", color: "firebrick", x: "width", align: "right", y: -5 },
-          encoding: { text: {type: "nominal", field: "R2"}  }
-        }
+        transform: [
+          {regression: axisY, on: axisX, params: true},
+          {calculate: '"R²: "+format(datum.rSquared, ".2f")', as: 'R2'}
+        ],
+        mark: {type: 'text', color: 'firebrick', x: 'width', align: 'right', y: -5},
+        encoding: {text: {type: 'nominal', field: 'R2'}}
       }
+    }
     if (color) {
       spec.layer[0].encoding.color = {field: color, type: 'nominal'}
     }
-    super('scatter', label, spec, { axisX, axisY, color, lm})
+    super('scatter', label, spec, {axisX, axisY, color, lm})
   }
 }
 

--- a/libs/ui/ui.jsx
+++ b/libs/ui/ui.jsx
@@ -401,7 +401,6 @@ export class TidyBlocksApp extends React.Component {
   }
 
   runProgram () {
-    console.log(this.blocklyRef.current.workspace.state.workspace.scale)
     TidyBlocksUI.runProgram()
     const env = TidyBlocksUI.env
     this.updateDataInformation(env)

--- a/libs/util.js
+++ b/libs/util.js
@@ -55,6 +55,16 @@ const equal = (left, right) => {
 }
 
 /**
+ * Turn something into a Boolean.
+ */
+const makeBoolean = (value) => {
+  if (value) {
+    return true
+  }
+  return false
+}
+
+/**
  * Turn something into a date.
  */
 const makeDate = (value) => {
@@ -140,6 +150,7 @@ module.exports = {
   checkNumber,
   checkTypeEqual,
   equal,
+  makeBoolean,
   makeDate,
   safeValue,
   csvToTable,

--- a/test/test_codegen.js
+++ b/test/test_codegen.js
@@ -507,7 +507,7 @@ describe('plot code generation', () => {
   })
 
   it('persists a scatter plot', (done) => {
-    const expected = [Transform.FAMILY, 'scatter', 'figure_1', 'red', 'green', 'blue']
+    const expected = [Transform.FAMILY, 'scatter', 'figure_1', 'red', 'green', 'blue', false]
     const w = workspace()
     const block = w.newBlock('plot_scatter')
     block.setFieldValue('figure_1', 'NAME')

--- a/test/test_transform.js
+++ b/test/test_transform.js
@@ -245,15 +245,15 @@ describe('build plots', () => {
     const transform = new Transform.scatter('figure_1', 'red', 'green', null)
     const result = transform.run(env, new DataFrame(fixture.COLORS))
     const plot = env.getPlot('figure_1')
-    assert.equal(plot.mark, 'point',
-                 `Wrong type of plot`)
     assert.deepEqual(plot.data.values, fixture.COLORS,
                      `Wrong data in plot`)
-    assert.equal(plot.encoding.x.field, 'red',
+    assert.equal(plot.layer[0].mark.type, 'point',
+                 `Wrong type of plot`)
+    assert.equal(plot.layer[0].encoding.x.field, 'red',
                  `Wrong X axis`)
-    assert.equal(plot.encoding.y.field, 'green',
+    assert.equal(plot.layer[0].encoding.y.field, 'green',
                  `Wrong Y axis`)
-    assert(!('color' in plot.encoding),
+    assert(!('color' in plot.layer[0].encoding),
            `Should not have color`)
     done()
   })
@@ -263,15 +263,15 @@ describe('build plots', () => {
     const transform = new Transform.scatter('figure_1', 'red', 'green', 'blue')
     const result = transform.run(env, new DataFrame(fixture.COLORS))
     const plot = env.getPlot('figure_1')
-    assert.equal(plot.mark, 'point',
-                 `Wrong type of plot`)
     assert.deepEqual(plot.data.values, fixture.COLORS,
                      `Wrong data in plot`)
-    assert.equal(plot.encoding.x.field, 'red',
+    assert.equal(plot.layer[0].mark.type, 'point',
+                 `Wrong type of plot`)
+    assert.equal(plot.layer[0].encoding.x.field, 'red',
                  `Wrong X axis`)
-    assert.equal(plot.encoding.y.field, 'green',
+    assert.equal(plot.layer[0].encoding.y.field, 'green',
                  `Wrong Y axis`)
-    assert.equal(plot.encoding.color.field, 'blue',
+    assert.equal(plot.layer[0].encoding.color.field, 'blue',
                  `Wrong color`)
     done()
   })


### PR DESCRIPTION
1. Consistent indentation - I need to figure out how to get my Emacs config to match the config that @MayaGans and @DarkMetroid are using.
2. Modify tests for scatterplots that were failing because of layers added for regression lines.
3. Add a `makeBoolean` function to localize the eslint complaints about unnecessarily convert values to Booleans.
4. Remove some unused imports.