### PR TITLE
Internationalizing blocks.

### DIFF
--- a/blocks/blocks.js
+++ b/blocks/blocks.js
@@ -227,18 +227,19 @@ let _createBlocksHasRun = false
 
 /**
  * Create block validators and blocks.
+ * @param {string} language What language to use for string table lookups.
  */
-const createBlocks = () => {
+const createBlocks = (language = 'en') => {
   if (!_createBlocksHasRun) {
     _createBlocksHasRun = true
     _createValidators()
-    combine.setup()
-    data.setup()
-    op.setup()
-    plot.setup()
-    stats.setup()
-    transform.setup()
-    value.setup()
+    combine.setup(language)
+    data.setup(language)
+    op.setup(language)
+    plot.setup(language)
+    stats.setup(language)
+    transform.setup(language)
+    value.setup(language)
   }
 }
 

--- a/blocks/combine.js
+++ b/blocks/combine.js
@@ -3,75 +3,116 @@
 const Blockly = require('blockly/blockly_compressed')
 
 /**
- * Define combining blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  glue: {
+    message0: {
+      en: 'Glue left %1 right %2 labels %3'
+    },
+    table_name: {
+      en: 'name'
+    },
+    label: {
+      en: 'label'
+    },
+    tooltip: {
+      en: 'glue rows from two tables together'
+    }
+  },
+  join: {
+    message0: {
+      en: 'Join'
+    },
+    message1: {
+      en: 'left %1 %2'
+    },
+    message2: {
+      en: 'right %1 %2'
+    },
+    table: {
+      en: 'table'
+    },
+    column: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'join two tables by matching values'
+    }
+  }
+}
+
+/**
+ * Define combining blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // Glue
     {
       type: 'combine_glue',
-      message0: 'Glue left %1 right %2 labels %3',
+      message0: MSG.glue.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'LEFT_TABLE',
-          text: 'name'
+          text: MSG.glue.table_name[language]
         },
         {
           type: 'field_input',
           name: 'RIGHT_TABLE',
-          text: 'name'
+          text: MSG.glue.table_name[language]
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'label'
+          text: MSG.glue.label[language]
         }
       ],
       inputsInline: false,
       nextStatement: null,
       style: 'combine_block',
       hat: 'cap',
-      tooltip: 'glue rows from two tables together',
+      tooltip: MSG.glue.tooltip[language],
       helpUrl: '',
       extensions: ['validate_LEFT_TABLE', 'validate_RIGHT_TABLE', 'validate_COLUMN']
     },
     // Join
     {
       type: 'combine_join',
-      message0: 'Join',
+      message0: MSG.join.message0[language],
       args0: [],
-      message1: 'left %1 %2',
+      message1: MSG.join.message1[language],
       args1: [
         {
           type: 'field_input',
           name: 'LEFT_TABLE',
-          text: 'table'
+          text: MSG.join.table[language]
         },
         {
           type: 'field_input',
           name: 'LEFT_COLUMN',
-          text: 'column'
+          text: MSG.join.column[language]
         }
       ],
-      message2: 'right %1 %2',
+      message2: MSG.join.message2[language],
       args2: [
         {
           type: 'field_input',
           name: 'RIGHT_TABLE',
-          text: 'table'
+          text: MSG.join.table[language]
         },
         {
           type: 'field_input',
           name: 'RIGHT_COLUMN',
-          text: 'column'
+          text: MSG.join.column[language]
         }
       ],
       inputsInline: false,
       nextStatement: null,
       style: 'combine_block',
       hat: 'cap',
-      tooltip: 'join two tables by matching values',
+      tooltip: MSG.join.tooltip[language],
       helpUrl: '',
       extensions: ['validate_LEFT_TABLE', 'validate_LEFT_COLUMN', 'validate_RIGHT_TABLE', 'validate_RIGHT_COLUMN']
     }

--- a/blocks/data.js
+++ b/blocks/data.js
@@ -3,46 +3,99 @@
 const Blockly = require('blockly/blockly_compressed')
 
 /**
- * Define data blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  colors: {
+    message0: {
+      en: 'Colors'
+    },
+    tooltip: {
+      en: 'eleven colors'
+    }
+  },
+  earthquakes: {
+    message0: {
+      en: 'Earthquakes'
+    },
+    tooltip: {
+      en: 'earthquake data'
+    }
+  },
+  penguins: {
+    message0: {
+      en: 'Penguins'
+    },
+    tooltip: {
+      en: 'penguin data'
+    }
+  },
+  sequence: {
+    message0: {
+      en: 'Sequence %1 %2'
+    },
+    args0_text: {
+      en: 'name'
+    },
+    tooltip: {
+      en: 'Generate a sequence 1..N'
+    }
+  },
+  data_user: {
+    message0: {
+      en: 'User data %1'
+    },
+    args0_text: {
+      en: 'name'
+    },
+    tooltip: {
+      en: 'use previously-loaded data'
+    }
+  }
+}
+
+/**
+ * Define data blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // Colors
     {
       type: 'data_colors',
-      message0: 'Colors',
+      message0: MSG.colors.message0[language],
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: 'eleven colors'
+      tooltip: MSG.colors.tooltip[language]
     },
     // Earthquakes
     {
       type: 'data_earthquakes',
-      message0: 'Earthquakes',
+      message0: MSG.earthquakes.message0[language],
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: 'earthquake data'
+      tooltip: MSG.earthquakes.tooltip[language]
     },
     // Penguins
     {
       type: 'data_penguins',
-      message0: 'Penguins',
+      message0: MSG.penguins.message0[language],
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: 'penguin data'
+      tooltip: MSG.penguins.tooltip[language]
     },
     // Sequence
     {
       type: 'data_sequence',
-      message0: 'Sequence %1 %2',
+      message0: MSG.sequence.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'name'
+          text: MSG.sequence.args0_text[language]
         },
         {
           type: 'field_number',
@@ -53,24 +106,24 @@ const setup = () => {
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: 'Generate a sequence 1..N',
+      tooltip: MSG.sequence.tooltip[language],
       helpUrl: ''
     },
     // User data
     {
       type: 'data_user',
-      message0: 'User data %1',
+      message0: MSG.data_user.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.data_user.args0_text[language]
         }
       ],
       nextStatement: null,
       style: 'data_block',
       hat: 'cap',
-      tooltip: 'use previously-loaded data',
+      tooltip: MSG.data_user.tooltip[language],
       helpUrl: ''
     }
   ])

--- a/blocks/op.js
+++ b/blocks/op.js
@@ -7,7 +7,77 @@ const {
   valueToCode
 } = require('./helpers')
 
-const setup = () => {
+/**
+ * Lookup table for message strings.
+ */
+const MSG = {
+  arithmetic: {
+    tooltip: {
+      en: 'do arithmetic'
+    }
+  },
+  negate: {
+    tooltip: {
+      en: 'negate a numeric column'
+    }
+  },
+  compare: {
+    tooltip: {
+      en: 'compare two columns'
+    }
+  },
+  logical: {
+    tooltip: {
+      en: 'combine logical values of two columns'
+    }
+  },
+  not: {
+    message0: {
+      en: 'not %1'
+    },
+    tooltip: {
+      en: 'negate a logical column'
+    }
+  },
+  type: {
+    message0: {
+      en: '%1 is %2 ?'
+    },
+    tooltip: {
+      en: 'check the type of a value'
+    }
+  },
+  convert: {
+    message0: {
+      en: '%1 to %2'
+    },
+    tooltip: {
+      en: 'change the datatype of a value'
+    }
+  },
+  datetime: {
+    message0: {
+      en: 'get %1 from %2'
+    },
+    tooltip: {
+      en: 'change the datatype of a value'
+    }
+  },
+  conditional: {
+    message0: {
+      en: 'If %1 then %2 else %3'
+    },
+    tooltip: {
+      en: 'select value based on condition'
+    }
+  }
+}
+
+/**
+ * Define operation blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // Binary arithmetic
     {
@@ -38,7 +108,7 @@ const setup = () => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: 'do arithmetic',
+      tooltip: MSG.arithmetic.tooltip[language],
       helpUrl: ''
     },
 
@@ -55,7 +125,7 @@ const setup = () => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: 'negate a numeric column',
+      tooltip: MSG.negate.tooltip[language],
       helpUrl: ''
     },
 
@@ -88,7 +158,7 @@ const setup = () => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: 'compare two columns',
+      tooltip: MSG.compare.tooltip[language],
       helpUrl: ''
     },
 
@@ -117,14 +187,14 @@ const setup = () => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: 'combine logical values of two columns',
+      tooltip: MSG.logical.tooltip[language],
       helpUrl: ''
     },
 
     // Logical negation
     {
       type: 'op_not',
-      message0: 'not %1',
+      message0: MSG.not.message0[language],
       args0: [
         {
           type: 'input_value',
@@ -134,14 +204,14 @@ const setup = () => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: 'negate a logical column',
+      tooltip: MSG.not.tooltip[language],
       helpUrl: ''
     },
 
     // Type checking
     {
       type: 'op_type',
-      message0: '%1 is %2 ?',
+      message0: MSG.type.message0[language],
       args0: [
         {
           type: 'input_value',
@@ -162,14 +232,14 @@ const setup = () => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: 'check the type of a value',
+      tooltip: MSG.type.tooltip[language],
       helpUrl: ''
     },
 
     // Type conversion
     {
       type: 'op_convert',
-      message0: '%1 to %2',
+      message0: MSG.convert.message0[language],
       args0: [
         {
           type: 'input_value',
@@ -189,14 +259,14 @@ const setup = () => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: 'change the datatype of a value',
+      tooltip: MSG.convert.tooltip[language],
       helpUrl: ''
     },
 
     // Datetime conversions
     {
       type: 'op_datetime',
-      message0: 'get %1 from %2',
+      message0: MSG.datetime.message0[language],
       args0: [
         {
           type: 'field_dropdown',
@@ -219,14 +289,14 @@ const setup = () => {
       inputsInline: true,
       output: 'Number',
       style: 'op_block',
-      tooltip: 'change the datatype of a value',
+      tooltip: MSG.datetime.tooltip[language],
       helpUrl: ''
     },
 
     // Conditional
     {
       type: 'op_conditional',
-      message0: 'If %1 then %2 else %3',
+      message0: MSG.conditional.message0[language],
       args0: [
         {
           type: 'input_value',
@@ -244,7 +314,7 @@ const setup = () => {
       inputsInline: true,
       output: 'Boolean',
       style: 'op_block',
-      tooltip: 'select value based on condition',
+      tooltip: MSG.conditional.tooltip[language],
       helpUrl: ''
     }
   ])

--- a/blocks/plot.js
+++ b/blocks/plot.js
@@ -3,36 +3,98 @@
 const Blockly = require('blockly/blockly_compressed')
 
 /**
- * Define plotting blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  name: {
+    en: 'name'
+  },
+  x_axis: {
+    en: 'X axis'
+  },
+  y_axis: {
+    en: 'Y axis'
+  },
+  plot_bar: {
+    message0: {
+      en: 'Bar %1 %2 %3'
+    },
+    tooltip: {
+      en: 'create bar plot'
+    }
+  },
+  plot_box: {
+    message0: {
+      en: 'Box %1 %2 %3'
+    },
+    tooltip: {
+      en: 'create box plot'
+    }
+  },
+  plot_dot: {
+    message0: {
+      en: 'Dot %1 %2'
+    },
+    tooltip: {
+      en: 'create dot plot'
+    }
+  },
+  plot_histogram: {
+    message0: {
+      en: 'Histogram %1 %2 %3'
+    },
+    column: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'create histogram'
+    }
+  },
+  plot_scatter: {
+    message0: {
+      en: 'Scatter %1 %2 %3 %4 Add Line? %5'
+    },
+    color: {
+      en: 'color'
+    },
+    tooltip: {
+      en: 'create scatter plot'
+    }
+  }
+}
+
+/**
+ * Define plotting blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // Bar plot
     {
       type: 'plot_bar',
-      message0: 'Bar %1 %2 %3',
+      message0: MSG.plot_bar.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.name[language]
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: 'X_axis'
+          text: MSG.x_axis[language]
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: 'Y_axis'
+          text: MSG.y_axis[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: 'create bar plot',
+      tooltip: MSG.plot_bar.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
@@ -40,29 +102,29 @@ const setup = () => {
     // Box plot
     {
       type: 'plot_box',
-      message0: 'Box %1 %2 %3',
+      message0: MSG.plot_box.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.name[language]
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: 'X_axis'
+          text: MSG.x_axis[language]
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: 'Y_axis'
+          text: MSG.y_axis[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: 'create box plot',
+      tooltip: MSG.plot_box.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS']
     },
@@ -70,24 +132,24 @@ const setup = () => {
     // Dot plot
     {
       type: 'plot_dot',
-      message0: 'Dot %1 %2',
+      message0: MSG.plot_dot.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.name[language]
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: 'X_axis'
+          text: MSG.x_axis[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: 'create dot plot',
+      tooltip: MSG.plot_dot.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS']
     },
@@ -95,17 +157,17 @@ const setup = () => {
     // Histogram plot
     {
       type: 'plot_histogram',
-      message0: 'Histogram %1 %2 %3',
+      message0: MSG.plot_histogram.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.name[language]
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'column'
+          text: MSG.plot_histogram.column[language]
         },
         {
           type: 'field_number',
@@ -117,7 +179,7 @@ const setup = () => {
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: 'create histogram',
+      tooltip: MSG.plot_histogram.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_COLUMN']
     },
@@ -125,27 +187,27 @@ const setup = () => {
     // Scatter plot
     {
       type: 'plot_scatter',
-      message0: 'Scatter %1 %2 %3 %4 Add Line? %5',
+      message0: MSG.plot_scatter.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.name[language]
         },
         {
           type: 'field_input',
           name: 'X_AXIS',
-          text: 'X_axis'
+          text: MSG.x_axis[language]
         },
         {
           type: 'field_input',
           name: 'Y_AXIS',
-          text: 'Y_axis'
+          text: MSG.y_axis[language]
         },
         {
           type: 'field_input',
           name: 'COLOR',
-          text: 'color'
+          text: MSG.plot_scatter.color[language]
         },
         {
           type: 'field_checkbox',
@@ -157,7 +219,7 @@ const setup = () => {
       previousStatement: null,
       nextStatement: null,
       style: 'plot_block',
-      tooltip: 'create scatter plot',
+      tooltip: MSG.plot_scatter.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME', 'validate_X_AXIS', 'validate_Y_AXIS', 'validate_COLOR']
     }

--- a/blocks/stats.js
+++ b/blocks/stats.js
@@ -3,26 +3,70 @@
 const Blockly = require('blockly/blockly_compressed')
 
 /**
- * Define statistics blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  stats_ttest_one: {
+    message0: {
+      en: 'One-sample t-test'
+    },
+    message1: {
+      en: 'name %1 column %2 mean \u03BC %3'
+    },
+    args1_name: {
+      en: 'name'
+    },
+    args1_column: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'perform one-sample two-sided t-test'
+    },
+  },
+  stats_ttest_two: {
+    message0: {
+      en: 'Two-sample t-test'
+    },
+    message1: {
+      en: 'name %1 labels %2 values %3'
+    },
+    args1_name: {
+      en: 'name'
+    },
+    args1_label: {
+      en: 'label'
+    },
+    args1_column: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'perform two-sample two-sided t-test'
+    }
+  }
+}
+
+/**
+ * Define statistics blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // One-sample two-sided t-test
     {
       type: 'stats_ttest_one',
-      message0: 'One-sample t-test',
+      message0: MSG.stats_ttest_one.message0[language],
       args0: [],
-      message1: 'name %1 column %2 mean \u03BC %3',
+      message1: MSG.stats_ttest_one.message1[language],
       args1: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.stats_ttest_one.args1_name[language]
         },
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'column'
+          text: MSG.stats_ttest_one.args1_column[language]
         },
         {
           type: 'field_number',
@@ -34,38 +78,38 @@ const setup = () => {
       previousStatement: null,
       nextStatement: null,
       style: 'stats_blocks',
-      tooltip: 'perform one-sample two-sided t-test',
+      tooltip: MSG.stats_ttest_one.tooltip[language],
       helpUrl: ''
     },
 
     // Two-sample two-sided t-test
     {
       type: 'stats_ttest_two',
-      message0: 'Two-sample t-test',
+      message0: MSG.stats_ttest_two.message0[language],
       args0: [],
-      message1: 'name %1 labels %2 values %3',
+      message1: MSG.stats_ttest_two.message1[language],
       args1: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.stats_ttest_two.args1_name[language]
         },
         {
           type: 'field_input',
           name: 'LABEL_COLUMN',
-          text: 'column'
+          text: MSG.stats_ttest_two.args1_label[language]
         },
         {
           type: 'field_input',
           name: 'VALUE_COLUMN',
-          text: 'column'
+          text: MSG.stats_ttest_two.args1_column[language]
         }
       ],
       inputsInline: false,
       previousStatement: null,
       nextStatement: null,
       style: 'stats_blocks',
-      tooltip: 'perform two-sample two-sided t-test',
+      tooltip: MSG.stats_ttest_two.tooltip[language],
       helpUrl: ''
     }
   ])

--- a/blocks/transform.js
+++ b/blocks/transform.js
@@ -8,7 +8,7 @@ const {
 } = require('./helpers')
 
 /**
- * Helper function to Turn a string containing comma-separated column names into
+ * Helper function to turn a string containing comma-separated column names into
  * an array of JavaScript strings.
  */
 const _formatMultiColNames = (raw) => {
@@ -22,19 +22,122 @@ const _formatMultiColNames = (raw) => {
 }
 
 /**
- * Define transform blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  multiple_columns: {
+    en: 'column, column'
+  },
+  create: {
+    message0: {
+      en: 'Create %1 %2'
+    },
+    args0_text: {
+      en: 'new_column'
+    },
+    tooltip: {
+      en: 'create new column from existing columns'
+    }
+  },
+  drop: {
+    message0: {
+      en: 'Drop %1'
+    },
+    args0_tooltip: {
+      en: 'drop columns by name'
+    }
+  },
+  filter: {
+    message0: {
+      en: 'Filter %1'
+    },
+    args0_name: {
+      en: 'TEST'
+    },
+    tooltip: {
+      en: 'filter rows by condition'
+    }
+  },
+  groupby: {
+    message0: {
+      en: 'Group by %1'
+    },
+    tooltip: {
+      en: 'group data by values in columns'
+    }
+  },
+  report: {
+    message0: {
+      en: 'Report %1'
+    },
+    args0_text: {
+      en: 'name'
+    },
+    tooltip: {
+      en: 'report a result'
+    }
+  },
+  select: {
+    message0: {
+      en: 'Select %1'
+    },
+    tooltip: {
+      en: 'select columns by name'
+    }
+  },
+  sort: {
+    message0: {
+      en: 'Sort %1 descending %2'
+    },
+    tooltip: {
+      en: 'sort table by multiple columns'
+    }
+  },
+  summarize: {
+    message0: {
+      en: 'Summarize %1 %2'
+    },
+    args0_text: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'summarize values in  column'
+    }
+  },
+  ungroup: {
+    message0: {
+      en: 'Ungroup'
+    },
+    tooltip: {
+      en: 'remove grouping'
+    }
+  },
+  unique: {
+    message0: {
+      en: 'Unique %1'
+    },
+    tooltip: {
+      en: 'select rows with unique values'
+    }
+  }
+}
+
+/**
+ * Define transform blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
+  console.log('SETUP WITH LANGUAGE', language)
   Blockly.defineBlocksWithJsonArray([
     // Create
     {
       type: 'transform_create',
-      message0: 'Create %1 %2',
+      message0: MSG.create.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'new_column'
+          text: MSG.create.args0_text[language]
         },
         {
           type: 'input_value',
@@ -45,7 +148,7 @@ const setup = () => {
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'create new column from existing columns',
+      tooltip: MSG.create.tooltip[language],
       helpUrl: '',
       extensions: ['validate_COLUMN']
     },
@@ -53,19 +156,19 @@ const setup = () => {
     // Drop
     {
       type: 'transform_drop',
-      message0: 'Drop %1',
+      message0: MSG.drop.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: 'column, column'
+          text: MSG.multiple_columns[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'drop columns by name',
+      tooltip: MSG.drop.args0_tooltip[language],
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -73,37 +176,37 @@ const setup = () => {
     // Filter
     {
       type: 'transform_filter',
-      message0: 'Filter %1',
+      message0: MSG.filter.message0[language],
       args0: [
         {
           type: 'input_value',
-          name: 'TEST'
+          name: MSG.filter.args0_name[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'filter rows by condition',
+      tooltip: MSG.filter.tooltip[language],
       helpUrl: ''
     },
 
     // Group
     {
       type: 'transform_groupBy',
-      message0: 'Group by %1',
+      message0: MSG.groupby.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: 'column, column'
+          text: MSG.multiple_columns[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'group data by values in columns',
+      tooltip: MSG.groupby.tooltip[language],
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -111,18 +214,18 @@ const setup = () => {
     // Report
     {
       type: 'transform_report',
-      message0: 'Report %1',
+      message0: MSG.report.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'NAME',
-          text: 'name'
+          text: MSG.report.args0_text[language]
         }
       ],
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'report a result',
+      tooltip: MSG.report.tooltip[language],
       helpUrl: '',
       extensions: ['validate_NAME']
     },
@@ -130,19 +233,19 @@ const setup = () => {
     // Select
     {
       type: 'transform_select',
-      message0: 'Select %1',
+      message0: MSG.select.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: 'column, column'
+          text: MSG.multiple_columns[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'select columns by name',
+      tooltip: MSG.select.tooltip[language],
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     },
@@ -150,12 +253,12 @@ const setup = () => {
     // Sort
     {
       type: 'transform_sort',
-      message0: 'Sort %1 descending %2',
+      message0: MSG.sort.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: 'column, column'
+          text: MSG.multiple_columns[language]
         },
         {
           type: 'field_checkbox',
@@ -168,14 +271,14 @@ const setup = () => {
       nextStatement: null,
       style: 'transform_block',
       extensions: ['validate_MULTIPLE_COLUMNS'],
-      tooltip: '',
+      tooltip: MSG.sort.tooltip[language],
       helpUrl: ''
     },
 
     // Summarize
     {
       type: 'transform_summarize',
-      message0: 'Summarize %1 %2',
+      message0: MSG.summarize.message0[language],
       args0: [
         {
           type: 'field_dropdown',
@@ -196,14 +299,14 @@ const setup = () => {
         {
           type: 'field_input',
           name: 'COLUMN',
-          text: 'column'
+          text: MSG.summarize.args0_text[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'summarize values in  column',
+      tooltip: MSG.summarize.tooltip[language],
       helpUrl: '',
       extensions: ['validate_COLUMN']
     },
@@ -211,32 +314,32 @@ const setup = () => {
     // Ungroup
     {
       type: 'transform_ungroup',
-      message0: 'Ungroup',
+      message0: MSG.ungroup.message0[language],
       args0: [],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'remove grouping',
+      tooltip: MSG.ungroup.tooltip[language],
       helpUrl: ''
     },
 
     // Unique
     {
       type: 'transform_unique',
-      message0: 'Unique %1',
+      message0: MSG.unique.message0[language],
       args0: [
         {
           type: 'field_input',
           name: 'MULTIPLE_COLUMNS',
-          text: 'column, column'
+          text: MSG.multiple_columns[language]
         }
       ],
       inputsInline: true,
       previousStatement: null,
       nextStatement: null,
       style: 'transform_block',
-      tooltip: 'select rows with unique values',
+      tooltip: MSG.unique.tooltip,
       helpUrl: '',
       extensions: ['validate_MULTIPLE_COLUMNS']
     }

--- a/blocks/value.js
+++ b/blocks/value.js
@@ -5,19 +5,100 @@ const Blockly = require('blockly/blockly_compressed')
 const {ORDER_NONE} = require('./helpers')
 
 /**
- * Define value blocks.
+ * Lookup table for message strings.
  */
-const setup = () => {
+const MSG = {
+  absent: {
+    message0: {
+      en: 'Absent'
+    },
+    tooltip: {
+      en: 'represent a hole'
+    }
+  },
+  column: {
+    column: {
+      en: 'column'
+    },
+    tooltip: {
+      en: 'get the value of a column'
+    }
+  },
+  datetime: {
+    text: {
+      en: 'YYYY-MM-DD'
+    },
+    tooltip: {
+      en: 'constant date/time'
+    }
+  },
+  logical: {
+    tooltip: {
+      en: 'logical constant'
+    }
+  },
+  number: {
+    tooltip: {
+      en: 'constant number'
+    }
+  },
+  text: {
+    text: {
+      en: 'text'
+    },
+    tooltip: {
+      en: 'constant text'
+    }
+  },
+  rownum: {
+    message0: {
+      en: 'Row number'
+    },
+    tooltip: {
+      en: 'row number'
+    }
+  },
+  exponential: {
+    message0: {
+      en: 'Exponential \u03BB %1'
+    },
+    tooltip: {
+      en: 'exponential random value'
+    }
+  },
+  normal: {
+    message0: {
+      en: 'Normal \u03BC %1 \u03C3 %2'
+    },
+    tooltip: {
+      en: 'normal random value'
+    }
+  },
+  uniform: {
+    message0: {
+      en: 'Uniform \u03B1 %1 \u03B2 %2'
+    },
+    tooltip: {
+      en: 'uniform random value'
+    }
+  }
+}
+
+/**
+ * Define value blocks.
+ * @param {string} language Two-letter language code to use for string lookups.
+ */
+const setup = (language) => {
   Blockly.defineBlocksWithJsonArray([
     // Absent value
     {
       type: 'value_absent',
-      message0: 'Absent',
+      message0: MSG.absent.message0[language],
       args0: [],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'represent a hole'
+      tooltip: MSG.absent.tooltip[language]
     },
 
     // Column name
@@ -27,12 +108,12 @@ const setup = () => {
       args0: [{
         type: 'field_input',
         name: 'COLUMN',
-        text: 'column'
+        text: MSG.column.column[language]
       }],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'get the value of a column',
+      tooltip: MSG.column.tooltip[language],
       extensions: ['validate_COLUMN']
     },
 
@@ -43,12 +124,12 @@ const setup = () => {
       args0: [{
         type: 'field_input',
         name: 'DATE',
-        text: 'YYYY-MM-DD'
+        text: MSG.datetime.text[language]
       }],
       output: 'DateTime',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'constant date/time',
+      tooltip: MSG.datetime.tooltip[language],
       extensions: ['validate_DATE']
     },
 
@@ -69,7 +150,7 @@ const setup = () => {
       output: 'Boolean',
       helpUrl: '',
       style: 'value_block',
-      tooltip: 'logical constant'
+      tooltip: MSG.logical.tooltip[language]
     },
 
     // Number
@@ -84,7 +165,7 @@ const setup = () => {
       output: 'Number',
       helpUrl: '',
       style: 'value_block',
-      tooltip: 'constant number'
+      tooltip: MSG.number.tooltip[language]
     },
 
     // Text
@@ -95,30 +176,30 @@ const setup = () => {
         {
           type: 'field_input',
           name: 'VALUE',
-          text: 'text'
+          text: MSG.text.text[language]
         }
       ],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'constant text'
+      tooltip: MSG.text.tooltip[language]
     },
 
     // Row number
     {
       type: 'value_rownum',
-      message0: 'Row number',
+      message0: MSG.rownum.message0[language],
       args0: [],
       output: 'String',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'row number'
+      tooltip: MSG.rownum.tooltip[language]
     },
 
     // Exponential random variable
     {
       type: 'value_exponential',
-      message0: 'Exponential \u03BB %1',
+      message0: MSG.exponential.message0[language],
       args0: [
         {
           type: 'field_input',
@@ -129,14 +210,14 @@ const setup = () => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'exponential random value',
+      tooltip: MSG.exponential.tooltip[language],
       extensions: ['validate_RATE']
     },
 
     // Normal random variable
     {
       type: 'value_normal',
-      message0: 'Normal \u03BC %1 \u03C3 %2',
+      message0: MSG.normal.message0[language],
       args0: [
         {
           type: 'field_input',
@@ -152,14 +233,14 @@ const setup = () => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'normal random value',
+      tooltip: MSG.normal.tooltip[language],
       extensions: ['validate_STDDEV']
     },
 
     // Uniform random variable
     {
       type: 'value_uniform',
-      message0: 'Uniform \u03B1 %1 \u03B2 %2',
+      message0: MSG.uniform.message0[language],
       args0: [
         {
           type: 'field_input',
@@ -175,7 +256,7 @@ const setup = () => {
       output: 'Number',
       style: 'value_block',
       helpUrl: '',
-      tooltip: 'uniform random value'
+      tooltip: MSG.uniform.tooltip[language]
     }
   ])
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script>
       let ui = null
       window.onload = () => {
-        TidyBlocksUI = tidyblocks.setup('root')
+        TidyBlocksUI = tidyblocks.setup('en', 'root')
       }
     </script>
   </head>

--- a/index.js
+++ b/index.js
@@ -16,10 +16,11 @@ const TidyBlocksApp = require('./libs/ui/ui').TidyBlocksApp
 class ReactInterface extends UserInterface {
   /**
    * Build user interface object.
+   * @param {string} language What language to use for localizing blocks.
    * @param {string} rootId HTML ID of root element.
    */
-  constructor (rootId) {
-    super()
+  constructor (language, rootId) {
+    super(language)
 
     // Create the Blockly settings.
     const settings = this._createSettings()
@@ -66,10 +67,11 @@ class ReactInterface extends UserInterface {
 
 /**
  * Initialize the interface.
- * @param rootId {string} HTML ID of element that will contain workspace.
+ * @param {string} language What language to use for localizing blocks.
+ * @param {string} rootId HTML ID of element that will contain workspace.
  */
-const setup = (rootId) => {
-  return new ReactInterface(rootId)
+const setup = (language, rootId) => {
+  return new ReactInterface(language, rootId)
 }
 
 module.exports = {

--- a/libs/gui.js
+++ b/libs/gui.js
@@ -19,10 +19,11 @@ const PENGUINS = require('../data/penguins')
 class UserInterface {
   /**
    * Build user interface object.
+   * @param {string} language What language to use for localizing blocks.
    */
-  constructor () {
+  constructor (language) {
     // Initialize blocks support.
-    blocks.createBlocks()
+    blocks.createBlocks(language)
 
     // Create storage for datasets loaded by the user. These are stored between
     // program runs.

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -50,11 +50,11 @@ class MockTransform extends Transform.base {
 }
 
 /**
- * User interface for testing purposes.
+ * User interface for testing purposes. Uses 'en' as a language unless told otherwise.
  */
 class TestInterface extends UserInterface {
-  constructor () {
-    super()
+  constructor (language = 'en') {
+    super(language)
     Blockly.Events.disable() // to stop it trying to create SVG
     this.workspace = new Blockly.Workspace({})
   }


### PR DESCRIPTION
- Adding 'language' key for internationalization to block creation functions and things that call it.
- Using 'en' as a default language to simplify testing.
- Adding message lookup keys for all blocks.

To do: get a language preference into the `setup` call.